### PR TITLE
Changing deluge/qbittorent to use href instead of origin

### DIFF
--- a/src/pages/api/modules/downloads.ts
+++ b/src/pages/api/modules/downloads.ts
@@ -17,14 +17,14 @@ async function Post(req: NextApiRequest, res: NextApiResponse) {
   switch (dlclient) {
     case 'qbit':
       client = new QBittorrent({
-        baseUrl: new URL(url).origin,
+        baseUrl: new URL(url).href,
         username,
         password,
       });
       break;
     case 'deluge':
       client = new Deluge({
-        baseUrl: new URL(url).origin,
+        baseUrl: new URL(url).href,
         password,
       });
       break;


### PR DESCRIPTION
Using origin omit basic authentication that be used for public facing torrents client.
Fix for my messed up PR request #172 
### Category
Feature

### Overview
Allow basic authentication for Deluge and qbittorrent since origin omit basic auth.

### Explanation
The current version use the origin of the URL, this is an issue for users running a Deluge or qbittorent webUI with extra basic authentication.
```
URL {
  href: 'https://deluge:REDACTED@deluge.REDACTED.xyz/',
  origin: 'https://deluge.REDACTED.xyz',
  protocol: 'https:',
  username: 'deluge',
  password: 'REDACTED',
  host: 'deluge.REDACTED.xyz',
  hostname: 'deluge.REDACTED.xyz',
  port: '',
  pathname: '/',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```

### Code Quality Checklist _(Please complete)_
- [x] All changes are backwards compatible
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] Bumps version, if new feature added
