### PR TITLE
Change title icons

### DIFF
--- a/src/components/Settings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings.tsx
@@ -1,49 +1,38 @@
 import { TextInput, Group, Button } from '@mantine/core';
-import { useState } from 'react';
+import { useForm } from '@mantine/form';
 import { useConfig } from '../../tools/state';
 
 export default function TitleChanger() {
   const { config, loadConfig, setConfig, getConfigs } = useConfig();
-  const [customTitle, setCustomTitle] = useState(config.title);
-  const [customLogo, setCustomLogo] = useState(config.logo);
-  const [customFavicon, setCustomFavicon] = useState(config.favicon);
 
-  const saveChanges = () => {
+  const form = useForm({
+    initialValues: {
+      title: config.settings.title,
+      logo: config.settings.logo,
+      favicon: config.settings.favicon,
+    },
+  });
+
+  const saveChanges = (values: { title: string; logo: string; favicon: string }) => {
     setConfig({
       ...config,
-      title: customTitle || "Homarr 🦞",
-      logo: customLogo || "/imgs/logo.png",
-      favicon: customFavicon || "/favicon.svg",
+      settings: {
+        ...config.settings,
+        title: values.title,
+        logo: values.logo,
+        favicon: values.favicon,
+      },
     });
-  }
+  };
 
   return (
-    <Group grow direction="column">
-      <TextInput
-        label="Page title"
-        defaultValue={config.title}
-        value={customTitle}
-        onChange={(event) => setCustomTitle(event.currentTarget.value)}
-      />
-      <TextInput
-        label="Logo"
-        defaultValue={config.logo}
-        value={customLogo}
-        onChange={(event) => setCustomLogo(event.currentTarget.value)}
-      />
-      <TextInput
-        label="Favicon"
-        defaultValue={config.favicon}
-        value={customFavicon}
-        onChange={(event) => setCustomFavicon(event.currentTarget.value)}
-      />
-      <Button
-        variant="gradient"
-        gradient={{ from: 'red', to: 'orange' }}
-        onClick={() => saveChanges()}
-      >
-        Save
-      </Button>
-    </Group>
+    <form onSubmit={form.onSubmit((values) => saveChanges(values))}>
+      <TextInput label="Page title" placeholder="'Homarr 🦞" {...form.getInputProps('title')} />
+      <TextInput label="Logo" placeholder="/img/logo.png" {...form.getInputProps('logo')} />
+      <TextInput label="Favicon" placeholder="/favicon.svg" {...form.getInputProps('favicon')} />
+      <Group grow position="center" mt="xl">
+        <Button type="submit">Save</Button>
+      </Group>
+    </form>
   );
 }

--- a/src/components/Settings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings.tsx
@@ -1,0 +1,49 @@
+import { TextInput, Group, Button } from '@mantine/core';
+import { useState } from 'react';
+import { useConfig } from '../../tools/state';
+
+export default function TitleChanger() {
+  const { config, loadConfig, setConfig, getConfigs } = useConfig();
+  const [customTitle, setCustomTitle] = useState(config.title);
+  const [customLogo, setCustomLogo] = useState(config.logo);
+  const [customFavicon, setCustomFavicon] = useState(config.favicon);
+
+  const saveChanges = () => {
+    setConfig({
+      ...config,
+      title: customTitle || "Homarr 🦞",
+      logo: customLogo || "/imgs/logo.png",
+      favicon: customFavicon || "/favicon.svg",
+    });
+  }
+
+  return (
+    <Group grow direction="column">
+      <TextInput
+        label="Page title"
+        defaultValue={config.title}
+        value={customTitle}
+        onChange={(event) => setCustomTitle(event.currentTarget.value)}
+      />
+      <TextInput
+        label="Logo"
+        defaultValue={config.logo}
+        value={customLogo}
+        onChange={(event) => setCustomLogo(event.currentTarget.value)}
+      />
+      <TextInput
+        label="Favicon"
+        defaultValue={config.favicon}
+        value={customFavicon}
+        onChange={(event) => setCustomFavicon(event.currentTarget.value)}
+      />
+      <Button
+        variant="gradient"
+        gradient={{ from: 'red', to: 'orange' }}
+        onClick={() => saveChanges()}
+      >
+        Save
+      </Button>
+    </Group>
+  );
+}

--- a/src/components/Settings/SettingsMenu.tsx
+++ b/src/components/Settings/SettingsMenu.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   Drawer,
   Anchor,
+  Tabs
 } from '@mantine/core';
 import { useColorScheme, useHotkeys } from '@mantine/hooks';
 import { useState } from 'react';
@@ -18,6 +19,7 @@ import { ColorSchemeSwitch } from '../ColorSchemeToggle/ColorSchemeSwitch';
 import ConfigChanger from '../Config/ConfigChanger';
 import SaveConfigComponent from '../Config/SaveConfig';
 import ModuleEnabler from './ModuleEnabler';
+import AdvancedSettings from './AdvancedSettings';
 
 function SettingsMenu(props: any) {
   const { config, setConfig } = useConfig();
@@ -37,95 +39,102 @@ function SettingsMenu(props: any) {
   );
 
   return (
-    <Group direction="column" grow>
-      <Group grow direction="column" spacing={0}>
-        <Text>Search engine</Text>
-        <SegmentedControl
-          fullWidth
-          title="Search engine"
-          value={
-            // Match config.settings.searchUrl with a key in the matches array
-            searchUrl
-          }
-          onChange={
-            // Set config.settings.searchUrl to the value of the selected item
-            (e) => {
-              setSearchUrl(e);
-              setConfig({
-                ...config,
-                settings: {
-                  ...config.settings,
-                  searchUrl: e,
-                },
-              });
-            }
-          }
-          data={matches}
-        />
-        {searchUrl === 'Custom' && (
-          <TextInput
-            label="Query URL"
-            placeholder="Custom query url"
-            value={customSearchUrl}
-            onChange={(event) => {
-              setCustomSearchUrl(event.currentTarget.value);
-              setConfig({
-                ...config,
-                settings: {
-                  ...config.settings,
-                  searchUrl: event.currentTarget.value,
-                },
-              });
-            }}
-          />
-        )}
-      </Group>
-      <ModuleEnabler />
-      <ColorSchemeSwitch />
-      <ConfigChanger />
-      <SaveConfigComponent />
-      <Text
-        style={{
-          alignSelf: 'center',
-          fontSize: '0.75rem',
-          textAlign: 'center',
-          color: 'gray',
-        }}
-      >
-        Tip: You can upload your config file by dragging and dropping it onto the page!
-      </Text>
-      <Group position="center" direction="row" mr="xs">
-        <Group spacing={0}>
-          <ActionIcon<'a'> component="a" href="https://github.com/ajnart/homarr" size="lg">
-            <BrandGithub size={18} />
-          </ActionIcon>
+    <Tabs>
+      <Tabs.Tab label="Settings">
+        <Group direction="column" grow>
+          <Group grow direction="column" spacing={0}>
+            <Text>Search engine</Text>
+            <SegmentedControl
+              fullWidth
+              title="Search engine"
+              value={
+                // Match config.settings.searchUrl with a key in the matches array
+                searchUrl
+              }
+              onChange={
+                // Set config.settings.searchUrl to the value of the selected item
+                (e) => {
+                  setSearchUrl(e);
+                  setConfig({
+                    ...config,
+                    settings: {
+                      ...config.settings,
+                      searchUrl: e,
+                    },
+                  });
+                }
+              }
+              data={matches}
+            />
+            {searchUrl === 'Custom' && (
+              <TextInput
+                label="Query URL"
+                placeholder="Custom query url"
+                value={customSearchUrl}
+                onChange={(event) => {
+                  setCustomSearchUrl(event.currentTarget.value);
+                  setConfig({
+                    ...config,
+                    settings: {
+                      ...config.settings,
+                      searchUrl: event.currentTarget.value,
+                    },
+                  });
+                }}
+              />
+            )}
+          </Group>
+          <ModuleEnabler />
+          <ColorSchemeSwitch />
+          <ConfigChanger />
+          <SaveConfigComponent />
           <Text
             style={{
-              position: 'relative',
-              fontSize: '0.90rem',
+              alignSelf: 'center',
+              fontSize: '0.75rem',
+              textAlign: 'center',
               color: 'gray',
             }}
           >
-            {CURRENT_VERSION}
+            Tip: You can upload your config file by dragging and dropping it onto the page!
           </Text>
+          <Group position="center" direction="row" mr="xs">
+            <Group spacing={0}>
+              <ActionIcon<'a'> component="a" href="https://github.com/ajnart/homarr" size="lg">
+                <BrandGithub size={18} />
+              </ActionIcon>
+              <Text
+                style={{
+                  position: 'relative',
+                  fontSize: '0.90rem',
+                  color: 'gray',
+                }}
+              >
+                {CURRENT_VERSION}
+              </Text>
+            </Group>
+            <Text
+              style={{
+                fontSize: '0.90rem',
+                textAlign: 'center',
+                color: 'gray',
+              }}
+            >
+              Made with ❤️ by @
+              <Anchor
+                href="https://github.com/ajnart"
+                style={{ color: 'inherit', fontStyle: 'inherit', fontSize: 'inherit' }}
+              >
+                ajnart
+              </Anchor>
+            </Text>
+          </Group>
         </Group>
-        <Text
-          style={{
-            fontSize: '0.90rem',
-            textAlign: 'center',
-            color: 'gray',
-          }}
-        >
-          Made with ❤️ by @
-          <Anchor
-            href="https://github.com/ajnart"
-            style={{ color: 'inherit', fontStyle: 'inherit', fontSize: 'inherit' }}
-          >
-            ajnart
-          </Anchor>
-        </Text>
-      </Group>
-    </Group>
+      </Tabs.Tab>
+      <Tabs.Tab label="Advanced">
+        <AdvancedSettings />
+      </Tabs.Tab>
+    </Tabs>
   );
 }
 

--- a/src/components/layout/HeaderConfig.tsx
+++ b/src/components/layout/HeaderConfig.tsx
@@ -7,8 +7,8 @@ export function HeaderConfig(props: any) {
 
   return (
     <Head>
-      <title>{config.title ?? "Homarr 🦞"}</title>
-      <link rel="shortcut icon" href={config.favicon ?? "/favicon.svg"} />
+      <title>{config.settings.title || 'Homarr 🦞'}</title>
+      <link rel="shortcut icon" href={config.settings.favicon || '/favicon.svg'} />
     </Head>
   );
 }

--- a/src/components/layout/HeaderConfig.tsx
+++ b/src/components/layout/HeaderConfig.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Head from 'next/head';
+import { useConfig } from '../../tools/state';
+
+export function HeaderConfig(props: any) {
+  const { config } = useConfig();
+
+  return (
+    <Head>
+      <title>{config.title ?? "Homarr 🦞"}</title>
+      <link rel="shortcut icon" href={config.favicon ?? "/favicon.svg"} />
+    </Head>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { AppShell, createStyles } from '@mantine/core';
 import { Header } from './Header';
 import { Footer } from './Footer';
 import Aside from './Aside';
+import { HeaderConfig } from './HeaderConfig';
 
 const useStyles = createStyles((theme) => ({
   main: {},
@@ -10,11 +11,8 @@ const useStyles = createStyles((theme) => ({
 export default function Layout({ children, style }: any) {
   const { classes, cx } = useStyles();
   return (
-    <AppShell
-      aside={<Aside />}
-      header={<Header />}
-      footer={<Footer links={[]} />}
-    >
+    <AppShell aside={<Aside />} header={<Header />} footer={<Footer links={[]} />}>
+      <HeaderConfig />
       <main
         className={cx(classes.main)}
         style={{

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -1,13 +1,16 @@
 import { Group, Image, Text } from '@mantine/core';
 import { NextLink } from '@mantine/next';
 import * as React from 'react';
+import { useConfig } from '../../tools/state';
 
 export function Logo({ style }: any) {
+  const { config } = useConfig();
+
   return (
     <Group spacing="xs">
       <Image
         width={50}
-        src="/imgs/logo.png"
+        src={config.logo ?? "/imgs/logo.png"}
         style={{
           position: 'relative',
         }}
@@ -25,7 +28,8 @@ export function Logo({ style }: any) {
           variant="gradient"
           gradient={{ from: 'red', to: 'orange', deg: 145 }}
         >
-          Homarr
+          {/* Added the .replace to remove emojis because they get screwed up by the gradient */}
+          {config.title.replace(/([\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '') ?? "Homarr"}
         </Text>
       </NextLink>
     </Group>

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -10,7 +10,7 @@ export function Logo({ style }: any) {
     <Group spacing="xs">
       <Image
         width={50}
-        src={config.logo ?? "/imgs/logo.png"}
+        src={config.settings.logo || '/imgs/logo.png'}
         style={{
           position: 'relative',
         }}
@@ -28,8 +28,7 @@ export function Logo({ style }: any) {
           variant="gradient"
           gradient={{ from: 'red', to: 'orange', deg: 145 }}
         >
-          {/* Added the .replace to remove emojis because they get screwed up by the gradient */}
-          {config.title.replace(/([\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '') ?? "Homarr"}
+          {config.settings.title || 'Homarr'}
         </Text>
       </NextLink>
     </Group>

--- a/src/tools/getConfig.ts
+++ b/src/tools/getConfig.ts
@@ -10,6 +10,9 @@ export function getConfig(name: string) {
         configName: name,
         config: {
           name: name.toString(),
+          title: 'Homarr 🦞',
+          logo: '/imgs/logo.png',
+          favicon: '/favicon.svg',
           services: [],
           settings: {
             searchUrl: 'https://www.google.com/search?q=',

--- a/src/tools/state.tsx
+++ b/src/tools/state.tsx
@@ -15,17 +15,17 @@ type configContextType = {
 const configContext = createContext<configContextType>({
   config: {
     name: 'default',
-    title: 'Homarr 🦞',
-    logo: '/imgs/logo.png',
-    favicon: '/favicon.svg',
     services: [],
     settings: {
       searchUrl: 'https://google.com/search?q=',
+      title: '',
+      logo: '',
+      favicon: '',
     },
     modules: {},
   },
-  setConfig: () => { },
-  loadConfig: async (name: string) => { },
+  setConfig: () => {},
+  loadConfig: async (name: string) => {},
   getConfigs: async () => [],
 });
 
@@ -44,12 +44,12 @@ type Props = {
 export function ConfigProvider({ children }: Props) {
   const [config, setConfigInternal] = useState<Config>({
     name: 'default',
-    title: 'Homarr 🦞',
-    logo: '/imgs/logo.png',
-    favicon: '/favicon.svg',
     services: [],
     settings: {
       searchUrl: 'https://www.google.com/search?q=',
+      title: '',
+      logo: '',
+      favicon: '',
     },
     modules: {},
   });

--- a/src/tools/state.tsx
+++ b/src/tools/state.tsx
@@ -15,14 +15,17 @@ type configContextType = {
 const configContext = createContext<configContextType>({
   config: {
     name: 'default',
+    title: 'Homarr 🦞',
+    logo: '/imgs/logo.png',
+    favicon: '/favicon.svg',
     services: [],
     settings: {
       searchUrl: 'https://google.com/search?q=',
     },
     modules: {},
   },
-  setConfig: () => {},
-  loadConfig: async (name: string) => {},
+  setConfig: () => { },
+  loadConfig: async (name: string) => { },
   getConfigs: async () => [],
 });
 
@@ -41,6 +44,9 @@ type Props = {
 export function ConfigProvider({ children }: Props) {
   const [config, setConfigInternal] = useState<Config>({
     name: 'default',
+    title: 'Homarr 🦞',
+    logo: '/imgs/logo.png',
+    favicon: '/favicon.svg',
     services: [],
     settings: {
       searchUrl: 'https://www.google.com/search?q=',

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -2,13 +2,13 @@ import { OptionValues } from '../components/modules/modules';
 
 export interface Settings {
   searchUrl: string;
+  title: string;
+  logo: string;
+  favicon: string;
 }
 
 export interface Config {
   name: string;
-  title: string;
-  logo: string;
-  favicon: string;
   services: serviceItem[];
   settings: Settings;
   modules: {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -6,6 +6,9 @@ export interface Settings {
 
 export interface Config {
   name: string;
+  title: string;
+  logo: string;
+  favicon: string;
   services: serviceItem[];
   settings: Settings;
   modules: {


### PR DESCRIPTION
### Category
Feature

### Overview
Added the ability to change page title, icon, favicon, and header title. The 3 settings are available in the config file and are present in a new tab of the settings popout called "Advanced." Making the settings blank will revert them to the default settings. An option for expansion here is adding a toggle for the logo so it's not required, and just having the text show.

To see requested revisions please visit #182. Summary of changes so far:
- Swapped to using Mantine's `useForm` hook instead of writing my own form `onClick` button code
- Changed button styling to match the rest of the app
- Removed default values from inputs and made the placeholders show the "default" values
- Fixed linting (I hope, not sure why my VS Code is using doublequoted strings and adding spaces to empty objects honestly)
- Moved the default values to their respective locations in the code:
  - Page title and favicon in `src/components/layout/HeaderConfig.tsx`
  - Logo and title in `src/components/layout/Logo.tsx`
- Submitting an empty form will result in the values going back to their defaults

### Issue Number _(if applicable)_
#107 

### New Vars
`title`, `logo`, and `favicon` were added to the configuration file.

### Screenshot
![](https://i.imgur.com/g2e1MCF.png)
![](https://i.imgur.com/bBp2GXx.png)

### Code Quality Checklist
- [x] All changes are backwards compatible
- [x] There are no (new) build warnings or errors
- [x] Attribute is outlined in the schema and documented
- [ ] Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added
