### PR TITLE
Fix Sonarr Incorrect Dates

### DIFF
--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -111,26 +111,26 @@ function DayComponent(props: any) {
     props;
   const [opened, setOpened] = useState(false);
 
-  const day = renderdate.getDate();
+  const day = renderdate.toDateString();
 
   const readarrFiltered = readarrmedias.filter((media: any) => {
     const date = new Date(media.releaseDate);
-    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
+    return date.toDateString() === day;
   });
 
   const lidarrFiltered = lidarrmedias.filter((media: any) => {
     const date = new Date(media.releaseDate);
     // Return true if the date is renerdate without counting hours and minutes
-    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
+    return date.toDateString() === day;
   });
   const sonarrFiltered = sonarrmedias.filter((media: any) => {
     const date = new Date(media.airDateUtc);
-    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
+    return date.toDateString() === day;
   });
   const radarrFiltered = radarrmedias.filter((media: any) => {
     const date = new Date(media.inCinemas);
     // Return true if the date is renerdate without counting hours and minutes
-    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
+    return date.toDateString() === day;
   });
   if (
     sonarrFiltered.length === 0 &&

--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -111,27 +111,26 @@ function DayComponent(props: any) {
     props;
   const [opened, setOpened] = useState(false);
 
-  const day = renderdate.toDateString();
+  const day = renderdate.getDate();
 
   const readarrFiltered = readarrmedias.filter((media: any) => {
     const date = new Date(media.releaseDate);
-    return date.toDateString() === day;
+    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
   });
 
   const lidarrFiltered = lidarrmedias.filter((media: any) => {
     const date = new Date(media.releaseDate);
     // Return true if the date is renerdate without counting hours and minutes
-    return date.toDateString() === day;
+    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
   });
   const sonarrFiltered = sonarrmedias.filter((media: any) => {
-    const date = new Date(media.airDate);
-    // Return true if the date is renerdate without counting hours and minutes
-    return date.toDateString() === day;
+    const date = new Date(media.airDateUtc);
+    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
   });
   const radarrFiltered = radarrmedias.filter((media: any) => {
     const date = new Date(media.inCinemas);
     // Return true if the date is renerdate without counting hours and minutes
-    return date.toDateString() === day;
+    return date.getDate() === day && date.getMonth() === renderdate.getMonth();
   });
   if (
     sonarrFiltered.length === 0 &&


### PR DESCRIPTION
Due to how Sonarr gives dates, they recommend using UTC time when displaying it as it matches their calendar. Took some digging but it fixed it.

*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
> One of: Bugfix 

### Overview
> Changed Sonarr's API call to use UTC time, that way time's on the calendar are correct.

### Issue Number _(if applicable)_
> Related issue: #187


### Code Quality Checklist _(Please complete)_
- [x] All changes are backwards compatible
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] Bumps version, if new feature added
