### PR TITLE
fix: calendar current day for light theme

### DIFF
--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-children-prop */
-import { Box, Divider, Indicator, Popover, ScrollArea, createStyles, useMantineColorScheme } from '@mantine/core';
+import { Box, Divider, Indicator, Popover, ScrollArea, createStyles, useMantineTheme } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import { Calendar } from '@mantine/dates';
 import { IconCalendar as CalendarIcon } from '@tabler/icons';
@@ -25,13 +25,14 @@ export const CalendarModule: IModule = {
 
 export default function CalendarComponent(props: any) {
   const { config } = useConfig();
-  const { colorScheme } = useMantineColorScheme();
+  const theme = useMantineTheme();
   const { secondaryColor } = useColorTheme();
-  const useStyles = createStyles(() => ({
+  const useStyles = createStyles((theme) => ({
       weekend: {
       color: `${secondaryColor} !important`,
     },
   }));
+
   const [sonarrMedias, setSonarrMedias] = useState([] as any);
   const [lidarrMedias, setLidarrMedias] = useState([] as any);
   const [radarrMedias, setRadarrMedias] = useState([] as any);
@@ -100,7 +101,7 @@ export default function CalendarComponent(props: any) {
       onChange={(day: any) => {}}
       dayStyle={(date) =>
         date.getDay() === today.getDay() && date.getDate() === today.getDate()
-          ? { backgroundColor: colorScheme === 'dark' ? '#2C2E33' : '#f8f9fa' }
+          ? { backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[0] }
           : {}
       }
       dayClassName={(date, modifiers) =>

--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-children-prop */
-import { Box, Divider, Indicator, Popover, ScrollArea, createStyles } from '@mantine/core';
+import { Box, Divider, Indicator, Popover, ScrollArea, createStyles, useMantineColorScheme } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import { Calendar } from '@mantine/dates';
 import { IconCalendar as CalendarIcon } from '@tabler/icons';
@@ -25,6 +25,7 @@ export const CalendarModule: IModule = {
 
 export default function CalendarComponent(props: any) {
   const { config } = useConfig();
+  const { colorScheme } = useMantineColorScheme();
   const { secondaryColor } = useColorTheme();
   const useStyles = createStyles(() => ({
       weekend: {
@@ -99,8 +100,8 @@ export default function CalendarComponent(props: any) {
       onChange={(day: any) => {}}
       dayStyle={(date) =>
         date.getDay() === today.getDay() && date.getDate() === today.getDate()
-          ? { backgroundColor: '#2C2E33' }
-          : null
+          ? { backgroundColor: colorScheme === 'dark' ? '#2C2E33' : '#f8f9fa' }
+          : {}
       }
       dayClassName={(date, modifiers) =>
         cx({ [classes.weekend]: modifiers.weekend })


### PR DESCRIPTION
### Category
Bugfix 

### Overview
Fix current day in calendar for light theme, sorry missed to test on it... I'll be blind but it's working.

### Screenshot
<img width="311" alt="Screenshot 2022-06-11 at 11 24 34 PM" src="https://user-images.githubusercontent.com/6454197/173205362-59e13299-1557-4372-942f-884190796346.png">

### Code Quality Checklist _(Please complete)_
- [x] All changes are backwards compatible
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added
