### PR TITLE
Add Support for Transmission Username & Port

### DIFF
--- a/src/components/AppShelf/AddAppShelfItem.tsx
+++ b/src/components/AppShelf/AddAppShelfItem.tsx
@@ -112,6 +112,7 @@ export function AddAppShelfItemForm(props: { setOpened: (b: boolean) => void } &
       apiKey: props.apiKey ?? (undefined as unknown as string),
       username: props.username ?? (undefined as unknown as string),
       password: props.password ?? (undefined as unknown as string),
+      port: props.port ?? (undefined as unknown as string),
       openedUrl: props.openedUrl ?? (undefined as unknown as string),
     },
     validate: {
@@ -300,7 +301,7 @@ export function AddAppShelfItemForm(props: { setOpened: (b: boolean) => void } &
               />
             </>
           )}
-          {(form.values.type === 'Deluge' || form.values.type === 'Transmission') && (
+          {form.values.type === 'Deluge' && (
             <>
               <TextInput
                 required
@@ -313,6 +314,40 @@ export function AddAppShelfItemForm(props: { setOpened: (b: boolean) => void } &
                 error={form.errors.password && 'Invalid password'}
               />
             </>
+          )}
+          {form.values.type === 'Transmission' && (
+            <>
+              <TextInput
+                required
+                label="Username"
+                placeholder="admin"
+                value={form.values.username}
+                onChange={(event) => {
+                    form.setFieldValue('username', event.currentTarget.value);
+                }}
+                error={form.errors.username && 'Invalid username'}
+              />
+              <TextInput                
+                required
+                label="Password"
+                placeholder="password"
+                value={form.values.password}
+                onChange={(event) => {
+                  form.setFieldValue('password', event.currentTarget.value);
+                }}
+                error={form.errors.password && 'Invalid password'}
+              />
+              <TextInput                
+                required
+                label="Port"
+                placeholder="9091"
+                value={form.values.port}
+                onChange={(event) => {
+                  form.setFieldValue('port', event.currentTarget.value);
+                }}
+                error={form.errors.port && 'Invalid Port'}
+              />
+            </>          
           )}
         </Group>
 

--- a/src/components/AppShelf/AppShelfMenu.tsx
+++ b/src/components/AppShelf/AppShelfMenu.tsx
@@ -31,6 +31,7 @@ export default function AppShelfMenu(props: any) {
           apiKey={service.apiKey}
           username={service.username}
           password={service.password}
+          port={service.port}
           openedUrl={service.openedUrl}
           message="Save service"
         />

--- a/src/pages/api/modules/downloads.ts
+++ b/src/pages/api/modules/downloads.ts
@@ -47,7 +47,7 @@ async function Post(req: NextApiRequest, res: NextApiResponse) {
     torrents.push(
       ...(
         await new Transmission({
-          baseUrl: transmissionService.url,
+          baseUrl: transmissionService.url + ":" + transmissionService.port,
           username: transmissionService.username,
           password: transmissionService.password,
         }).getAllData()


### PR DESCRIPTION
### Category
> Feature

### Overview
> Added new form fields to AppShelfItem to allow for user submitted username & port for Transmission service.

### Issue Number _(if applicable)_
> Related issue: #208

### New Vars _(if applicable)_
> port was added to AppShelfItemMenu

### Screenshot
https://i.imgur.com/xVclVXB.png