### PR TITLE
:bug: Origin URL in calendar to includes path

### DIFF
--- a/src/pages/api/modules/calendar.ts
+++ b/src/pages/api/modules/calendar.ts
@@ -44,7 +44,7 @@ async function Post(req: NextApiRequest, res: NextApiResponse) {
     });
   }
   // Get the origin URL
-  const { origin } = new URL(service.url);
+  const { href: origin } = new URL(service.url);
   const pined = `${origin}${url?.url}?apiKey=${service.apiKey}&end=${nextMonth}&start=${lastMonth}`;
   const data = await axios.get(
     `${origin}${url?.url}?apiKey=${service.apiKey}&end=${nextMonth}&start=${lastMonth}`


### PR DESCRIPTION
### Category
Bugfix

### Overview
Changed the origin variable in the calendar module to use the entire URL instead of just the origin domain.



### Issue Number
#215

### New Vars
N/A

### Screenshot
N/A
