### PR TITLE
🐛Fix completed torrents progress color

### DIFF
--- a/src/components/modules/downloads/DownloadsModule.tsx
+++ b/src/components/modules/downloads/DownloadsModule.tsx
@@ -158,7 +158,7 @@ export default function DownloadComponent() {
             <Progress
               radius="lg"
               color={
-                torrent.state === 'paused' ? 'yellow' : torrent.progress === 1 ? 'green' : 'blue'
+                torrent.progress === 1 ? 'green' : torrent.state === 'paused' ? 'yellow' : 'blue'
               }
               value={torrent.progress * 100}
               size="lg"


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix

### Overview
When torrents are not seeding and completed, they report as both progress === 1 and state === 'paused', the old logic checked if it was paused before it checked if it was completed. Now it checks if its completed before it checks if its paused.


### Screenshot _(if applicable)_
Before:
![image](https://user-images.githubusercontent.com/39219859/173714308-45e48218-0467-4d03-9009-ca5e22ce34b5.png)

After:
![image](https://user-images.githubusercontent.com/39219859/173714316-0f947cb4-65eb-48d0-9c65-e0a12a7fa8f2.png)

