### PR TITLE
🐛 Fix Calendar not loading content when a service fails

### DIFF
--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -73,6 +73,8 @@ export default function CalendarComponent(props: any) {
       sonarrServices.map((service) =>
         getMedias(service, 'sonarr').then((res) => {
           currentSonarrMedias.push(...res.data);
+        }).catch(() => {
+          currentSonarrMedias.push([]);
         })
       )
     ).then(() => {
@@ -83,6 +85,8 @@ export default function CalendarComponent(props: any) {
       radarrServices.map((service) =>
         getMedias(service, 'radarr').then((res) => {
           currentRadarrMedias.push(...res.data);
+        }).catch(() => {
+          currentRadarrMedias.push([]);
         })
       )
     ).then(() => {
@@ -93,6 +97,8 @@ export default function CalendarComponent(props: any) {
       lidarrServices.map((service) =>
         getMedias(service, 'lidarr').then((res) => {
           currentLidarrMedias.push(...res.data);
+        }).catch(() => {
+          currentLidarrMedias.push([]);
         })
       )
     ).then(() => {
@@ -103,6 +109,8 @@ export default function CalendarComponent(props: any) {
       readarrServices.map((service) =>
         getMedias(service, 'readarr').then((res) => {
           currentReadarrMedias.push(...res.data);
+        }).catch(() => {
+          currentReadarrMedias.push([]);
         })
       )
     ).then(() => {


### PR DESCRIPTION
Fix no content showing when 1 of the same service is down.

*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix

### Overview
If you have multiple of the same Arr services, (Ex. 2 Sonarrs), and 1 of the 2 fail, then the calendar fails to display any media.

This was due to it not having a catch statement for when data acquisition would fail and cause an error.
