### PR TITLE
🐛Fix Calendar Duplicate Entries

### DIFF
--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -68,7 +68,7 @@ export default function CalendarComponent(props: any) {
 
   useEffect(() => {
     // Create each Sonarr service and get the medias
-    const currentSonarrMedias: any[] = [...sonarrMedias];
+    const currentSonarrMedias: any[] = [];
     Promise.all(
       sonarrServices.map((service) =>
         getMedias(service, 'sonarr').then((res) => {
@@ -78,7 +78,7 @@ export default function CalendarComponent(props: any) {
     ).then(() => {
       setSonarrMedias(currentSonarrMedias);
     });
-    const currentRadarrMedias: any[] = [...radarrMedias];
+    const currentRadarrMedias: any[] = [];
     Promise.all(
       radarrServices.map((service) =>
         getMedias(service, 'radarr').then((res) => {
@@ -88,7 +88,7 @@ export default function CalendarComponent(props: any) {
     ).then(() => {
       setRadarrMedias(currentRadarrMedias);
     });
-    const currentLidarrMedias: any[] = [...lidarrMedias];
+    const currentLidarrMedias: any[] = [];
     Promise.all(
       lidarrServices.map((service) =>
         getMedias(service, 'lidarr').then((res) => {
@@ -98,7 +98,7 @@ export default function CalendarComponent(props: any) {
     ).then(() => {
       setLidarrMedias(currentLidarrMedias);
     });
-    const currentReadarrMedias: any[] = [...readarrMedias];
+    const currentReadarrMedias: any[] = [];
     Promise.all(
       readarrServices.map((service) =>
         getMedias(service, 'readarr').then((res) => {


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix

### Overview
When moving services around it caused duplicate date entries, it would do this by grabbing pre-existing entries from itself. 
I do not know why these entries would exist but removing this acquisition solves the issue.

