### PR TITLE
🐛 Fix Calendar Item Duplication

### DIFF
--- a/src/components/modules/calendar/CalendarModule.tsx
+++ b/src/components/modules/calendar/CalendarModule.tsx
@@ -68,7 +68,7 @@ export default function CalendarComponent(props: any) {
 
   useEffect(() => {
     // Create each Sonarr service and get the medias
-    const currentSonarrMedias: any[] = [...sonarrMedias];
+    const currentSonarrMedias: any[] = [];
     Promise.all(
       sonarrServices.map((service) =>
         getMedias(service, 'sonarr').then((res) => {
@@ -80,7 +80,7 @@ export default function CalendarComponent(props: any) {
     ).then(() => {
       setSonarrMedias(currentSonarrMedias);
     });
-    const currentRadarrMedias: any[] = [...radarrMedias];
+    const currentRadarrMedias: any[] = [];
     Promise.all(
       radarrServices.map((service) =>
         getMedias(service, 'radarr').then((res) => {
@@ -92,7 +92,7 @@ export default function CalendarComponent(props: any) {
     ).then(() => {
       setRadarrMedias(currentRadarrMedias);
     });
-    const currentLidarrMedias: any[] = [...lidarrMedias];
+    const currentLidarrMedias: any[] = [];
     Promise.all(
       lidarrServices.map((service) =>
         getMedias(service, 'lidarr').then((res) => {
@@ -104,7 +104,7 @@ export default function CalendarComponent(props: any) {
     ).then(() => {
       setLidarrMedias(currentLidarrMedias);
     });
-    const currentReadarrMedias: any[] = [...readarrMedias];
+    const currentReadarrMedias: any[] = [];
     Promise.all(
       readarrServices.map((service) =>
         getMedias(service, 'readarr').then((res) => {


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix

### Overview
- https://github.com/ajnart/homarr/commit/6fd23cf6a003a2e666cea30dfb9e031e6e0e6e12 changed how items for the calendar are acquired, making it so every series gets updated when a new one gets added, or one gets moved. This causes the entries in the calendar to duplicate due to old code being left in. The way before this feature change was to grab the old calendar items, and add new items on top of that.
- The sections of code I added made it so instead of the array of calendar entries starting with the old entries, it starts empty, this way duplicates do not occur.

**I have not been able to replicate any bugs reported in #231, so if anyone is able to explain how to replicate them, I can most likely adjust the changes to account for any new issues, although I've done some thorough testing and can't seem to find any new bugs.**

### Issue Number _(if applicable)_
#176 
