### PR TITLE
🐛Allow multiple of the same torrent client +1

### DIFF
--- a/src/components/AppShelf/AddAppShelfItem.tsx
+++ b/src/components/AppShelf/AddAppShelfItem.tsx
@@ -298,53 +298,64 @@ export function AddAppShelfItemForm(props: { setOpened: (b: boolean) => void } &
                   </>
                 )}
                 {form.values.type === 'qBittorrent' && (
-                  <>
-                    <TextInput
-                      required
-                      label="Username"
-                      placeholder="admin"
-                      value={form.values.username}
-                      onChange={(event) => {
-                        form.setFieldValue('username', event.currentTarget.value);
-                      }}
-                      error={form.errors.username && 'Invalid username'}
-                    />
-                    <TextInput
-                      required
-                      label="Password"
-                      placeholder="adminadmin"
-                      value={form.values.password}
-                      onChange={(event) => {
-                        form.setFieldValue('password', event.currentTarget.value);
-                      }}
-                      error={form.errors.password && 'Invalid password'}
-                    />
-                  </>
-                )}
-                {(form.values.type === 'Deluge' ||
-                  form.values.type === 'Transmission' ||
-                  form.values.type === 'qBittorrent') && (
-                  <>
-                    <TextInput
-                      label="Username"
-                      placeholder="admin"
-                      value={form.values.username}
-                      onChange={(event) => {
-                        form.setFieldValue('username', event.currentTarget.value);
-                      }}
-                      error={form.errors.username && 'Invalid username'}
-                    />
-                    <TextInput
-                      label="Password"
-                      placeholder="password"
-                      value={form.values.password}
-                      onChange={(event) => {
-                        form.setFieldValue('password', event.currentTarget.value);
-                      }}
-                      error={form.errors.password && 'Invalid password'}
-                    />
-                  </>
-                )}
+              <>
+                <TextInput
+                  required
+                  label="Username"
+                  placeholder="admin"
+                  value={form.values.username}
+                  onChange={(event) => {
+                    form.setFieldValue('username', event.currentTarget.value);
+                  }}
+                  error={form.errors.username && 'Invalid username'}
+                />
+                <TextInput
+                  required
+                  label="Password"
+                  placeholder="adminadmin"
+                  value={form.values.password}
+                  onChange={(event) => {
+                    form.setFieldValue('password', event.currentTarget.value);
+                  }}
+                  error={form.errors.password && 'Invalid password'}
+                />
+              </>
+            )}
+            {form.values.type === 'Deluge' && (
+              <>
+                <TextInput
+                  label="Password"
+                  placeholder="password"
+                  value={form.values.password}
+                  onChange={(event) => {
+                    form.setFieldValue('password', event.currentTarget.value);
+                  }}
+                  error={form.errors.password && 'Invalid password'}
+                />
+              </>
+            )}
+            {form.values.type === 'Transmission' && (
+              <>
+              <TextInput
+                label="Username"
+                placeholder="admin"
+                value={form.values.username}
+                onChange={(event) => {
+                  form.setFieldValue('username', event.currentTarget.value);
+                }}
+                error={form.errors.username && 'Invalid username'}
+              />
+              <TextInput
+                label="Password"
+                placeholder="adminadmin"
+                value={form.values.password}
+                onChange={(event) => {
+                  form.setFieldValue('password', event.currentTarget.value);
+                }}
+                error={form.errors.password && 'Invalid password'}
+              />
+            </>
+            )}
               </Group>
             </ScrollArea>
           </Tabs.Tab>

--- a/src/pages/api/modules/downloads.ts
+++ b/src/pages/api/modules/downloads.ts
@@ -53,7 +53,7 @@ async function Post(req: NextApiRequest, res: NextApiResponse) {
         ...(
           await new Transmission({
             baseUrl: service.url,
-            username: service.username,
+            username: 'username' in service ? service.username : '',
             password: 'password' in service ? service.password : '',
           }).getAllData()
         ).torrents


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix

### Overview
This allows you to have more than 1 of the same type of download client.

The code is somewhat similar to #176's fix but using a modern for loop, I couldn't use a forEach() or a map() as the async wouldn't allow proper pushing to the torrents array. And because I could use React's useState I used a regular for loop.

**Edit: Also fixed Torrent's credential requirements for deluge and transmission**

### Issue Number
#241 


### Screenshot
![opera_z1CX5vq4YS](https://user-images.githubusercontent.com/39219859/174678594-84ff7574-41c7-492d-ab37-ebabaefcd3aa.png)

