### PR TITLE
Fix Readarr default port number

### DIFF
--- a/src/components/AppShelf/AddAppShelfItem.tsx
+++ b/src/components/AppShelf/AddAppShelfItem.tsx
@@ -81,7 +81,7 @@ function MatchPort(name: string, form: any) {
     { name: 'sonarr', value: '8989' },
     { name: 'radarr', value: '7878' },
     { name: 'lidarr', value: '8686' },
-    { name: 'readarr', value: '8686' },
+    { name: 'readarr', value: '8787' },
     { name: 'deluge', value: '8112' },
     { name: 'transmission', value: '9091' },
   ];


### PR DESCRIPTION
### Category - Bugfix 

### Overview
Fix default port for when adding Readarr, currently `8686` but should be `8787` I'm not sure if this change I've made is entirely sufficient for the fix?

See [https://wiki.servarr.com/readarr](https://wiki.servarr.com/readarr).
