### PR TITLE
♻️ Change Docker instance to singleton

### DIFF
--- a/src/pages/api/docker/DockerSingleton.tsx
+++ b/src/pages/api/docker/DockerSingleton.tsx
@@ -4,16 +4,13 @@ export default class DockerSingleton extends Docker {
   private static dockerInstance: DockerSingleton;
 
   private constructor() {
-    super({
-      host: '192.168.1.56',
-      port: 2376,
-    });
+    super();
   }
 
   public static getInstance(): DockerSingleton {
-    if (!this.dockerInstance) {
-      this.dockerInstance = new this();
+    if (!DockerSingleton.dockerInstance) {
+      DockerSingleton.dockerInstance = new DockerSingleton();
     }
-    return this.dockerInstance;
+    return DockerSingleton.dockerInstance;
   }
 }

--- a/src/pages/api/docker/DockerSingleton.tsx
+++ b/src/pages/api/docker/DockerSingleton.tsx
@@ -1,0 +1,19 @@
+import Docker from 'dockerode';
+
+export default class DockerSingleton extends Docker {
+  private static dockerInstance: DockerSingleton;
+
+  private constructor() {
+    super({
+      host: '192.168.1.56',
+      port: 2376,
+    });
+  }
+
+  public static getInstance(): DockerSingleton {
+    if (!this.dockerInstance) {
+      this.dockerInstance = new this();
+    }
+    return this.dockerInstance;
+  }
+}

--- a/src/pages/api/docker/container/[id].tsx
+++ b/src/pages/api/docker/container/[id].tsx
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import Docker from 'dockerode';
+import DockerSingleton from '../DockerSingleton';
 
-const docker = new Docker();
+const docker = DockerSingleton.getInstance();
 
 async function Get(req: NextApiRequest, res: NextApiResponse) {
   // Get the slug of the request

--- a/src/pages/api/docker/containers.tsx
+++ b/src/pages/api/docker/containers.tsx
@@ -1,10 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-
-import Docker from 'dockerode';
+import DockerSingleton from './DockerSingleton';
 
 async function Get(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const docker = new Docker();
+    const docker = DockerSingleton.getInstance();
     const containers = await docker.listContainers({ all: true });
     res.status(200).json(containers);
   } catch (err) {


### PR DESCRIPTION
### Category
> Refactoring Only

### Overview
> Change the way to access to the Docker socket. Instead of creating a new connection to the socket and a new instance of the Docker object, a singleton has been implemented to manipulate Docker through one connection and one instance.