### PR TITLE
:sparkles: Add option for custom CSS to Customization Settings

### DIFF
--- a/public/locales/de/settings/customization/page-appearance.json
+++ b/public/locales/de/settings/customization/page-appearance.json
@@ -15,6 +15,10 @@
     "label": "Hintergrund",
     "placeholder": "/img/background.png"
   },
+  "customCSS": {
+    "label": "Benutzerdefiniertes CSS",
+    "placeholder": "Benutzerdefiniertes CSS wird als letztes ausgeführt"
+  },
   "buttons": {
     "submit": "Absenden"
   }

--- a/public/locales/en/settings/customization/page-appearance.json
+++ b/public/locales/en/settings/customization/page-appearance.json
@@ -15,6 +15,10 @@
     "label": "Background",
     "placeholder": "/img/background.png"
   },
+  "customCSS": {
+    "label": "Custom CSS",
+    "placeholder": "Custom CSS will be executed last"
+  },
   "buttons": {
     "submit": "Submit"
   }

--- a/src/components/Settings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import { TextInput, Button, Stack } from '@mantine/core';
+import { TextInput, Button, Stack, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useTranslation } from 'next-i18next';
 import { useConfig } from '../../tools/state';
@@ -25,6 +25,7 @@ export default function TitleChanger() {
     logo?: string;
     favicon?: string;
     background?: string;
+    customCSS?: string;
   }) => {
     setConfig({
       ...config,
@@ -34,6 +35,7 @@ export default function TitleChanger() {
         logo: values.logo,
         favicon: values.favicon,
         background: values.background,
+        customCSS: values.customCSS,
       },
     });
   };
@@ -61,6 +63,12 @@ export default function TitleChanger() {
             label={t('background.label')}
             placeholder={t('background.placeholder')}
             {...form.getInputProps('background')}
+          />
+          <Textarea
+            minRows={5}
+            label="Custom CSS"
+            placeholder="Your CSS will be executed last"
+            {...form.getInputProps('customCSS')}
           />
           <Button type="submit">{t('buttons.submit')}</Button>
         </Stack>

--- a/src/components/Settings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings.tsx
@@ -67,8 +67,8 @@ export default function TitleChanger() {
           />
           <Textarea
             minRows={5}
-            label="Custom CSS"
-            placeholder="Your CSS will be executed last"
+            label={t('customCSS.label')}
+            placeholder={t('customCSS.placeholder')}
             {...form.getInputProps('customCSS')}
           />
           <Button type="submit">{t('buttons.submit')}</Button>

--- a/src/components/Settings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings.tsx
@@ -17,6 +17,7 @@ export default function TitleChanger() {
       logo: config.settings.logo,
       favicon: config.settings.favicon,
       background: config.settings.background,
+      customCSS: config.settings.customCSS,
     },
   });
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -34,6 +34,9 @@ export default function Layout({ children, style }: any) {
       >
         {children}
       </main>
+      <style>
+        {cx(config.settings.customCSS)}
+      </style>
     </AppShell>
   );
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -10,6 +10,7 @@ export interface Settings {
   secondaryColor?: MantineTheme['primaryColor'];
   primaryShade?: MantineTheme['primaryShade'];
   background?: string;
+  customCSS?: string,
   appOpacity?: number;
   widgetPosition?: string;
   appCardWidth?: number;


### PR DESCRIPTION
### Category
> Feature

### Overview
> Adds a textarea for sutom css to the Customize Settings Tab. The css is loaded in a <style> below <main>

### Issue Number
> Related issue: #339

### Screenshot
> ![Customize Settings](https://user-images.githubusercontent.com/46794825/186278387-96fbc4ea-0265-4e36-a5f8-0c9db9a67f49.png)
