### PR TITLE
Fix integrations url on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Homarr is a simple and lightweight homepage for your server, that helps you easi
 
 It integrates with the services you use to display information on the homepage (E.g. Show upcoming Sonarr/Radarr releases).
 
-For a full list of integrations, [head over to our documentation](https://homarr.vercel.app/docs/advanced-features/integrations).
+For a full list of integrations, [head over to our documentation](https://homarr.vercel.app/docs/advanced-configuration/integrations).
 
 If you have any questions about Homarr or want to share information with us, please go to one of the following places:
 


### PR DESCRIPTION
### Category
Documentation (README)

### Overview
The current url is sending to `advanced-features/integrations` and return 404. 
I think it should be `advanced-configuration/integrations`, as far as I have seen
