### PR TITLE
:pencil2: Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you have any questions about Homarr or want to share information with us, ple
 - [Github Discussions](https://github.com/ajnart/homarr/discussions)
 - [Discord Server](https://discord.gg/aCsmEV5RgA)
 
-*Before you file an [issue](https://github.com/ajnart/homarr/issues/new/choose), make sure you have the read [known issues](#-known-issues) section.*
+*Before you file an [issue](https://github.com/ajnart/homarr/issues/new/choose), make sure you have read the [known issues](#-known-issues) section.*
 
 **For more information, [read the documentation!](https://homarr.vercel.app/docs/about)**
 


### PR DESCRIPTION
### Category
> Documentation

### Overview
> Fixed a typo in the README.md file
