### PR TITLE
:adhesive_bandage: Fix *seerr API key link (#446)

### DIFF
--- a/src/components/AppShelf/AddAppShelfItem.tsx
+++ b/src/components/AppShelf/AddAppShelfItem.tsx
@@ -26,6 +26,7 @@ import { useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useConfig } from '../../tools/state';
 import { tryMatchPort, ServiceTypeList, StatusCodes, Config } from '../../tools/types';
+import apiKeyPaths from './apiKeyPaths.json';
 import Tip from '../layout/Tip';
 
 export function AddItemShelfButton(props: any) {
@@ -307,7 +308,7 @@ export function AddAppShelfItemForm(props: AddAppShelfItemFormProps) {
                       target="_blank"
                       weight="bold"
                       style={{ fontStyle: 'inherit', fontSize: 'inherit' }}
-                      href={`${hostname}/settings/general`}
+                      href={`${hostname}/${apiKeyPaths[form.values.type as keyof typeof apiKeyPaths]}`}
                     >
                       {t('modal.tabs.options.form.integrations.apiKey.tip.link')}
                     </Anchor>

--- a/src/components/AppShelf/apiKeyPaths.json
+++ b/src/components/AppShelf/apiKeyPaths.json
@@ -1,0 +1,9 @@
+{
+  "Jellyseerr": "settings",
+  "Overseerr": "settings",
+  "Sonarr": "settings/general",
+  "Radarr": "settings/general",
+  "Readarr": "settings/general",
+  "Lidarr": "settings/general",
+  "Sabnzbd": "settings/general"
+}

--- a/src/components/AppShelf/apiKeyPaths.json
+++ b/src/components/AppShelf/apiKeyPaths.json
@@ -5,5 +5,5 @@
   "Radarr": "settings/general",
   "Readarr": "settings/general",
   "Lidarr": "settings/general",
-  "Sabnzbd": "sabnzbd/config"
+  "Sabnzbd": "sabnzbd/config/general"
 }

--- a/src/components/AppShelf/apiKeyPaths.json
+++ b/src/components/AppShelf/apiKeyPaths.json
@@ -5,5 +5,5 @@
   "Radarr": "settings/general",
   "Readarr": "settings/general",
   "Lidarr": "settings/general",
-  "Sabnzbd": "settings/general"
+  "Sabnzbd": "sabnzbd/config"
 }


### PR DESCRIPTION
### Category
>Bugfix

### Overview
Created a JSON file to add the API Key path for each service instead of using /settings/general for the "Get your API key here" tip (Mainly because Overseerr and Jellyseerr use `/settings` instead of `/settings/general`)

### Issue Number
> Related issue: #446 

### New Vars
> `components/AppShelf/apiKeyPaths.json`: Stores the path used for each service