### PR TITLE
:bug: Fix HTTP status code bug

### DIFF
--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/NetworkTab/NetworkTab.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/NetworkTab/NetworkTab.tsx
@@ -22,14 +22,14 @@ export const NetworkTab = ({ form }: NetworkTabProps) => {
       {form.values.network.enabledStatusChecker && (
         <MultiSelect
           required
-          label={t('network.statusCodes.label')}
-          description={t('network.statusCodes.description')}
+          label={t('network.okStatus.label')}
+          description={t('network.okStatus.description')}
           data={StatusCodes}
           clearable
           searchable
           defaultValue={form.values.network.okStatus}
           variant="default"
-          {...form.getInputProps('network.statusCodes')}
+          {...form.getInputProps('network.okStatus')}
         />
       )}
     </Tabs.Panel>


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix 

### Overview
The ping status is not honoring what is configured in the Network tab HTTP status codes for the app. It looks like this is because the ping status is looking at a different config section then where the Network tab is saving the HTTP status codes to. I changed the Network tab to save the HTTP status codes to the same config section the ping status is expecting.

### Issue Number _(if applicable)_
N/A

### New Vars _(if applicable)_
N/A

### Screenshot _(if applicable)_
N/A
