### PR TITLE
🐛 rename okStatus to statusCodes

### DIFF
--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/NetworkTab/NetworkTab.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/NetworkTab/NetworkTab.tsx
@@ -27,7 +27,7 @@ export const NetworkTab = ({ form }: NetworkTabProps) => {
           data={StatusCodes}
           clearable
           searchable
-          defaultValue={form.values.network.okStatus}
+          defaultValue={form.values.network.statusCodes}
           variant="default"
           {...form.getInputProps('network.statusCodes')}
         />

--- a/src/components/Dashboard/Modals/SelectElement/Components/Overview/AvailableElementsOverview.tsx
+++ b/src/components/Dashboard/Modals/SelectElement/Components/Overview/AvailableElementsOverview.tsx
@@ -95,7 +95,7 @@ export const AvailableElementTypes = ({
                   },
                   network: {
                     enabledStatusChecker: true,
-                    okStatus: [200],
+                    statusCodes: [200],
                   },
                   behaviour: {
                     isOpeningNewTab: true,

--- a/src/components/Dashboard/Tiles/Apps/AppPing.tsx
+++ b/src/components/Dashboard/Tiles/Apps/AppPing.tsx
@@ -19,7 +19,7 @@ export const AppPing = ({ app }: AppPingProps) => {
     queryKey: [`ping/${app.id}`],
     queryFn: async () => {
       const response = await fetch(`/api/modules/ping?url=${encodeURI(app.url)}`);
-      const isOk = app.network.okStatus.includes(response.status);
+      const isOk = app.network.statusCodes.includes(response.status);
       return {
         status: response.status,
         state: isOk ? 'online' : 'down',

--- a/src/modules/Docker/ContainerActionBar.tsx
+++ b/src/modules/Docker/ContainerActionBar.tsx
@@ -178,7 +178,7 @@ export default function ContainerActionBar({ selected, reload }: ContainerAction
                 },
                 network: {
                   enabledStatusChecker: true,
-                  okStatus: [200],
+                  statusCodes: [200],
                 },
                 behaviour: {
                   isOpeningNewTab: true,

--- a/src/tools/config/migrateConfig.ts
+++ b/src/tools/config/migrateConfig.ts
@@ -157,7 +157,7 @@ const migrateService = (oldService: serviceItem, areaType: AreaType): AppType =>
   },
   network: {
     enabledStatusChecker: oldService.ping ?? true,
-    okStatus: oldService.status?.map((str) => parseInt(str, 10)) ?? [200],
+    statusCodes: oldService.status?.map((str) => parseInt(str, 10)) ?? [200],
   },
   appearance: {
     iconUrl: migrateIcon(oldService.icon),

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -22,7 +22,7 @@ interface AppBehaviourType {
 
 interface AppNetworkType {
   enabledStatusChecker: boolean;
-  okStatus: number[];
+  statusCodes: number[];
 }
 
 interface AppAppearanceType {


### PR DESCRIPTION
Thanks to #596 and @jonjon1123 , we can fix the incoherences between `okStatus` and `statusCodes`