### PR TITLE
feat: add support for default ports on http(s) protocols

### DIFF
--- a/src/pages/api/modules/usenet/history.ts
+++ b/src/pages/api/modules/usenet/history.ts
@@ -39,7 +39,7 @@ async function Get(req: NextApiRequest, res: NextApiResponse) {
         const url = new URL(app.url);
         const options = {
           host: url.hostname,
-          port: url.port,
+          port: url.port || (url.protocol === 'https:' ? '443' : '80'),
           login: app.integration.properties.find((x) => x.field === 'username')?.value ?? undefined,
           hash: app.integration.properties.find((x) => x.field === 'password')?.value ?? undefined,
         };

--- a/src/pages/api/modules/usenet/index.ts
+++ b/src/pages/api/modules/usenet/index.ts
@@ -38,7 +38,7 @@ async function Get(req: NextApiRequest, res: NextApiResponse) {
         const url = new URL(app.url);
         const options = {
           host: url.hostname,
-          port: url.port,
+          port: url.port || (url.protocol === 'https:' ? '443' : '80'),
           login: app.integration.properties.find((x) => x.field === 'username')?.value ?? undefined,
           hash: app.integration.properties.find((x) => x.field === 'password')?.value ?? undefined,
         };

--- a/src/pages/api/modules/usenet/pause.ts
+++ b/src/pages/api/modules/usenet/pause.ts
@@ -30,7 +30,7 @@ async function Post(req: NextApiRequest, res: NextApiResponse) {
         const url = new URL(app.url);
         const options = {
           host: url.hostname,
-          port: url.port,
+          port: url.port || (url.protocol === 'https:' ? '443' : '80'),
           login: app.integration.properties.find((x) => x.field === 'username')?.value ?? undefined,
           hash: app.integration.properties.find((x) => x.field === 'password')?.value ?? undefined,
         };

--- a/src/pages/api/modules/usenet/queue.ts
+++ b/src/pages/api/modules/usenet/queue.ts
@@ -39,7 +39,7 @@ async function Get(req: NextApiRequest, res: NextApiResponse) {
         const url = new URL(app.url);
         const options = {
           host: url.hostname,
-          port: url.port,
+          port: url.port || (url.protocol === 'https:' ? '443' : '80'),
           login: app.integration.properties.find((x) => x.field === 'username')?.value ?? undefined,
           hash: app.integration.properties.find((x) => x.field === 'password')?.value ?? undefined,
         };

--- a/src/pages/api/modules/usenet/resume.ts
+++ b/src/pages/api/modules/usenet/resume.ts
@@ -31,7 +31,7 @@ async function Post(req: NextApiRequest, res: NextApiResponse) {
         const url = new URL(app.url);
         const options = {
           host: url.hostname,
-          port: url.port,
+          port: url.port || (url.protocol === 'https:' ? '443' : '80'),
           login: app.integration.properties.find((x) => x.field === 'username')?.value ?? undefined,
           hash: app.integration.properties.find((x) => x.field === 'password')?.value ?? undefined,
         };


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
> One of: Bugfix

### Overview
For internal ip/urls if the application exists on port 80 or 443. `new Url` will not set port. So this will add defaults based on protocol for http or https.

### Issue Number _(if applicable)_
> Related issue: https://github.com/ajnart/homarr/issues/642

### New Vars _(if applicable)_
n/a

### Screenshot _(if applicable)_
n/a
