### PR TITLE
Add category collapse

### DIFF
--- a/src/components/Dashboard/Wrappers/Category/Category.tsx
+++ b/src/components/Dashboard/Wrappers/Category/Category.tsx
@@ -15,8 +15,8 @@ interface DashboardCategoryProps {
 export const DashboardCategory = ({ category }: DashboardCategoryProps) => {
   const { refs, apps, widgets } = useGridstack('category', category.id);
   const isEditMode = useEditModeStore((x) => x.enabled);
-  const { classes: cardClasses } = useCardStyles(true);
   const { config } = useConfigContext();
+  const { classes: cardClasses } = useCardStyles(true);
 
   const categoryList = config?.categories.map((x) => x.name) ?? [];
   const [toggledCategories, setToggledCategories] = useLocalStorage({
@@ -34,7 +34,7 @@ export const DashboardCategory = ({ category }: DashboardCategoryProps) => {
       chevronPosition="left"
       multiple
       value={isEditMode ? categoryList : toggledCategories}
-      variant="filled"
+      variant="separated"
       radius="lg"
       onChange={(state) => {
         // Cancel if edit mode is on

--- a/src/components/Dashboard/Wrappers/Category/Category.tsx
+++ b/src/components/Dashboard/Wrappers/Category/Category.tsx
@@ -1,6 +1,8 @@
-import { Group, Title } from '@mantine/core';
+import { Accordion, Title } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
+import { useConfigContext } from '../../../../config/provider';
 import { CategoryType } from '../../../../types/category';
-import { HomarrCardWrapper } from '../../Tiles/HomarrCardWrapper';
+import { useCardStyles } from '../../../layout/useCardStyles';
 import { useEditModeStore } from '../../Views/useEditModeStore';
 import { useGridstack } from '../gridstack/use-gridstack';
 import { WrapperContent } from '../WrapperContent';
@@ -13,20 +15,47 @@ interface DashboardCategoryProps {
 export const DashboardCategory = ({ category }: DashboardCategoryProps) => {
   const { refs, apps, widgets } = useGridstack('category', category.id);
   const isEditMode = useEditModeStore((x) => x.enabled);
+  const { classes: cardClasses } = useCardStyles(true);
+  const { config } = useConfigContext();
+
+  const categoryList = config?.categories.map((x) => x.name) ?? [];
+  const [toggledCategories, setToggledCategories] = useLocalStorage({
+    key: `${config?.configProperties.name}-app-shelf-toggled`,
+    // This is a bit of a hack to toggle the categories on the first load, return a string[] of the categories
+    defaultValue: categoryList,
+  });
 
   return (
-    <HomarrCardWrapper pt={10} mx={10} isCategory>
-      <Group position="apart" align="center">
-        <Title order={3}>{category.name}</Title>
-        {isEditMode ? <CategoryEditMenu category={category} /> : null}
-      </Group>
-      <div
-        className="grid-stack grid-stack-category"
-        data-category={category.id}
-        ref={refs.wrapper}
-      >
-        <WrapperContent apps={apps} refs={refs} widgets={widgets} />
-      </div>
-    </HomarrCardWrapper>
+    <Accordion
+      classNames={{
+        item: cardClasses.card,
+      }}
+      mx={0}
+      chevronPosition="left"
+      multiple
+      value={isEditMode ? categoryList : toggledCategories}
+      variant="filled"
+      radius="lg"
+      onChange={(state) => {
+        // Cancel if edit mode is on
+        if (isEditMode) return;
+        setToggledCategories([...state]);
+      }}
+    >
+      <Accordion.Item value={category.name}>
+        <Accordion.Control icon={isEditMode && <CategoryEditMenu category={category} />}>
+          <Title order={3}>{category.name}</Title>
+        </Accordion.Control>
+        <Accordion.Panel>
+          <div
+            className="grid-stack grid-stack-category"
+            data-category={category.id}
+            ref={refs.wrapper}
+          >
+            <WrapperContent apps={apps} refs={refs} widgets={widgets} />
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
   );
 };

--- a/src/components/Dashboard/Wrappers/Category/CategoryEditMenu.tsx
+++ b/src/components/Dashboard/Wrappers/Category/CategoryEditMenu.tsx
@@ -22,7 +22,7 @@ export const CategoryEditMenu = ({ category }: CategoryEditMenuProps) => {
     useCategoryActions(configName, category);
 
   return (
-    <Menu withinPortal position="left-start" withArrow>
+    <Menu withinPortal withArrow>
       <Menu.Target>
         <ActionIcon>
           <IconDots />


### PR DESCRIPTION
Fixes #636

# Info 
- Categories are all expanded by default. They can't be collapsed in edit mode to prevent people from collapsing them and then putting apps after then, pushing away apps when it expands and breaking the order of apps
- Category expansion is config-based in local storage
- Compatible with transparent configs
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/49837342/214878200-ea26b083-c214-4a18-b910-09d627489761.png">


<img width="1352" alt="image" src="https://user-images.githubusercontent.com/49837342/214875377-e115f011-1b97-4464-a79f-545ffe1f3795.png">

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/49837342/214875387-69ff8277-d604-4860-a97d-35a6156cd1bb.png">
