### PR TITLE
🐛 Fix StatusCode not being used properly

### DIFF
--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/NetworkTab/NetworkTab.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/NetworkTab/NetworkTab.tsx
@@ -10,6 +10,9 @@ interface NetworkTabProps {
 
 export const NetworkTab = ({ form }: NetworkTabProps) => {
   const { t } = useTranslation('layout/modals/add-app');
+  const acceptableStatusCodes = (form.values.network.statusCodes ?? ['200']).map((x) =>
+    x.toString()
+  );
   return (
     <Tabs.Panel value="network" pt="lg">
       <Switch
@@ -27,7 +30,7 @@ export const NetworkTab = ({ form }: NetworkTabProps) => {
           data={StatusCodes}
           clearable
           searchable
-          defaultValue={form.values.network.okStatus.map((x) => `${x}`)}
+          defaultValue={acceptableStatusCodes}
           variant="default"
           {...form.getInputProps('network.statusCodes')}
         />

--- a/src/components/Dashboard/Modals/SelectElement/Components/Overview/AvailableElementsOverview.tsx
+++ b/src/components/Dashboard/Modals/SelectElement/Components/Overview/AvailableElementsOverview.tsx
@@ -95,7 +95,7 @@ export const AvailableElementTypes = ({
                   },
                   network: {
                     enabledStatusChecker: true,
-                    okStatus: [200],
+                    statusCodes: ['200'],
                   },
                   behaviour: {
                     isOpeningNewTab: true,

--- a/src/components/Dashboard/Tiles/Apps/AppPing.tsx
+++ b/src/components/Dashboard/Tiles/Apps/AppPing.tsx
@@ -19,7 +19,7 @@ export const AppPing = ({ app }: AppPingProps) => {
     queryKey: ['ping', { id: app.id, name: app.name }],
     queryFn: async () => {
       const response = await fetch(`/api/modules/ping?url=${encodeURI(app.url)}`);
-      const isOk = app.network.okStatus.includes(response.status);
+      const isOk = app.network.statusCodes.includes(response.status.toString());
       return {
         status: response.status,
         state: isOk ? 'online' : 'down',
@@ -60,5 +60,3 @@ export const AppPing = ({ app }: AppPingProps) => {
     </motion.div>
   );
 };
-
-type PingState = 'loading' | 'down' | 'online';

--- a/src/modules/Docker/ContainerActionBar.tsx
+++ b/src/modules/Docker/ContainerActionBar.tsx
@@ -177,7 +177,7 @@ export default function ContainerActionBar({ selected, reload }: ContainerAction
                 },
                 network: {
                   enabledStatusChecker: true,
-                  okStatus: [200],
+                  statusCodes: ['200'],
                 },
                 behaviour: {
                   isOpeningNewTab: true,

--- a/src/tools/config/migrateConfig.ts
+++ b/src/tools/config/migrateConfig.ts
@@ -159,7 +159,7 @@ const migrateService = (oldService: serviceItem, areaType: AreaType): ConfigAppT
   },
   network: {
     enabledStatusChecker: oldService.ping ?? true,
-    okStatus: oldService.status?.map((str) => parseInt(str, 10)) ?? [200],
+    statusCodes: oldService.status ?? ['200'],
   },
   appearance: {
     iconUrl: migrateIcon(oldService.icon),

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -23,7 +23,7 @@ interface AppBehaviourType {
 
 interface AppNetworkType {
   enabledStatusChecker: boolean;
-  okStatus: number[];
+  statusCodes: string[];
 }
 
 interface AppAppearanceType {


### PR DESCRIPTION
Fixes #726

Issue was just a type miscommunication, we renamed 'okStatus' to 'statusCodes' and forgot to change it in the type definitions