### PR TITLE
✨ Add Docker as a widget

### DIFF
--- a/src/components/Settings/Customization/Layout/LayoutSelector.tsx
+++ b/src/components/Settings/Customization/Layout/LayoutSelector.tsx
@@ -78,10 +78,7 @@ export const LayoutSelector = () => {
         <Paper px="xs" py={4} withBorder>
           <Group position="apart">
             <Logo size="xs" />
-            <Group spacing={5}>
-              {searchBar && <PlaceholderElement width={60} height={10} />}
-              {docker && <PlaceholderElement width={10} height={10} />}
-            </Group>
+            <Group spacing={5}>{searchBar && <PlaceholderElement width={60} height={10} />}</Group>
           </Group>
         </Paper>
 
@@ -151,11 +148,6 @@ export const LayoutSelector = () => {
             label={t('layout.enablesearchbar')}
             checked={searchBar}
             onChange={(ev) => handleChange('enabledSearchbar', ev, setSearchBar)}
-          />
-          <Checkbox
-            label={t('layout.enabledocker')}
-            checked={docker}
-            onChange={(ev) => handleChange('enabledDocker', ev, setDocker)}
           />
           <Checkbox
             label={t('layout.enableping')}

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -2,7 +2,6 @@ import { Box, createStyles, Group, Header as MantineHeader, Indicator } from '@m
 import { useQuery } from '@tanstack/react-query';
 import { REPO_URL } from '../../../../data/constants';
 import { useEditModeInformationStore } from '../../../hooks/useEditModeInformation';
-import DockerMenuButton from '../../../modules/Docker/DockerModule';
 import { usePackageAttributesStore } from '../../../tools/client/zustands/usePackageAttributesStore';
 import { Logo } from '../Logo';
 import { useCardStyles } from '../useCardStyles';
@@ -42,7 +41,6 @@ export function Header(props: any) {
         >
           <Search />
           {!editModeEnabled && <ToggleEditModeAction />}
-          <DockerMenuButton />
           <Indicator
             size={15}
             color="blue"

--- a/src/modules/Docker/DockerModule.tsx
+++ b/src/modules/Docker/DockerModule.tsx
@@ -78,7 +78,13 @@ export default function DockerMenuButton(props: any) {
           },
         }}
       >
-        <DockerTable containers={containers} selection={selection} setSelection={setSelection} />
+        <DockerTable
+          hideSearchBar={false}
+          widgetMode={false}
+          containers={containers}
+          selection={selection}
+          setSelection={setSelection}
+        />
       </Drawer>
       <Tooltip label={t('actionIcon.tooltip')}>
         <ActionIcon

--- a/src/modules/Docker/DockerTable.tsx
+++ b/src/modules/Docker/DockerTable.tsx
@@ -29,8 +29,12 @@ export default function DockerTable({
   containers,
   selection,
   setSelection,
+  widgetMode,
+  hideSearchBar,
 }: {
   setSelection: any;
+  widgetMode: boolean;
+  hideSearchBar: boolean;
   containers: Dockerode.ContainerInfo[];
   selection: Dockerode.ContainerInfo[];
 }) {
@@ -72,13 +76,15 @@ export default function DockerTable({
     const selected = selection.includes(element);
     return (
       <tr key={element.Id} className={cx({ [classes.rowSelected]: selected })}>
-        <td>
-          <Checkbox
-            checked={selection.includes(element)}
-            onChange={() => toggleRow(element)}
-            transitionDuration={0}
-          />
-        </td>
+        {!widgetMode && (
+          <td>
+            <Checkbox
+              checked={selection.includes(element)}
+              onChange={() => toggleRow(element)}
+              transitionDuration={0}
+            />
+          </td>
+        )}
         <td>
           <Text size="lg" weight={600}>
             {element.Names[0].replace('/', '')}
@@ -121,26 +127,30 @@ export default function DockerTable({
 
   return (
     <ScrollArea style={{ height: '100%' }} offsetScrollbars>
-      <TextInput
-        placeholder={t('search.placeholder')}
-        mr="md"
-        icon={<IconSearch size={14} />}
-        value={search}
-        autoFocus
-        onChange={handleSearchChange}
-      />
-      <Table ref={ref} captionSide="bottom" highlightOnHover verticalSpacing="sm">
+      {!hideSearchBar && (
+        <TextInput
+          placeholder={t('search.placeholder')}
+          mr="md"
+          icon={<IconSearch size={14} />}
+          value={search}
+          autoFocus
+          onChange={handleSearchChange}
+        />
+      )}
+      <Table ref={ref} captionSide="bottom" highlightOnHover={!widgetMode} verticalSpacing="sm">
         <thead>
           <tr>
-            <th style={{ width: 40 }}>
-              <Checkbox
-                onChange={toggleAll}
-                checked={selection.length === usedContainers.length && selection.length > 0}
-                indeterminate={selection.length > 0 && selection.length !== usedContainers.length}
-                transitionDuration={0}
-                disabled={usedContainers.length === 0}
-              />
-            </th>
+            {!widgetMode && (
+              <th style={{ width: 40 }}>
+                <Checkbox
+                  onChange={toggleAll}
+                  checked={selection.length === usedContainers.length && selection.length > 0}
+                  indeterminate={selection.length > 0 && selection.length !== usedContainers.length}
+                  transitionDuration={0}
+                  disabled={usedContainers.length === 0}
+                />
+              </th>
+            )}
             <th>{t('table.header.name')}</th>
             {width > MIN_WIDTH_MOBILE ? <th>{t('table.header.image')}</th> : null}
             {width > MIN_WIDTH_MOBILE ? <th>{t('table.header.ports')}</th> : null}

--- a/src/widgets/docker/DockerTile.tsx
+++ b/src/widgets/docker/DockerTile.tsx
@@ -1,0 +1,141 @@
+import { IconArrowsMaximize, IconBrandDocker } from '@tabler/icons';
+import { useState } from 'react';
+import axios from 'axios';
+import Docker from 'dockerode';
+import { useQuery } from '@tanstack/react-query';
+import { ActionIcon, Drawer, Loader, Stack, Text, Title } from '@mantine/core';
+import { useTranslation } from 'next-i18next';
+import { useHotkeys } from '@mantine/hooks';
+import { IWidget } from '../widgets';
+import { defineWidget } from '../helper';
+import DockerTable from '../../modules/Docker/DockerTable';
+import ContainerActionBar from '../../modules/Docker/ContainerActionBar';
+import { useEditModeStore } from '../../components/Dashboard/Views/useEditModeStore';
+
+const definition = defineWidget({
+  id: 'docker',
+  icon: IconBrandDocker,
+  options: {
+    hideSearchBar: {
+      type: 'switch',
+      defaultValue: false,
+    },
+  },
+
+  gridstack: {
+    minWidth: 2,
+    minHeight: 1,
+    maxWidth: 12,
+    maxHeight: 6,
+  },
+  component: DockerWidgetTable,
+});
+
+export type IDockerWidget = IWidget<(typeof definition)['id'], typeof definition>;
+
+interface DockerTileProps {
+  widget: IDockerWidget;
+}
+
+export default definition;
+
+export function DockerWidgetTable({ widget }: DockerTileProps) {
+  const [selection, setSelection] = useState<Docker.ContainerInfo[]>([]);
+  const { hideSearchBar } = widget.properties;
+  const { t } = useTranslation('modules/docker');
+  const [opened, setOpened] = useState(false);
+  useHotkeys([['mod+B', () => setOpened(!opened)]]);
+  const isEditMode = useEditModeStore((x) => x.enabled);
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['docker'],
+    queryFn: () => axios.get('/api/docker/containers', { timeout: 2000 }),
+    staleTime: 1000 * 60,
+    retry: 1,
+    refetchOnWindowFocus: false,
+    cacheTime: 0,
+  });
+  if (isLoading) {
+    return (
+      <Stack
+        align="center"
+        justify="center"
+        style={{
+          height: '100%',
+        }}
+      >
+        <Loader variant="bars" />
+        <Stack align="center" spacing={0}>
+          <Text color="dimmed">Loading your docker containers...</Text>
+        </Stack>
+      </Stack>
+    );
+  }
+  if (!data || error) {
+    return (
+      <Stack style={{ height: '100%' }} align="center" justify="center">
+        <Title order={3}>{t('errors.integrationFailed.title')}</Title>
+        <Text>{t('errors.integrationFailed.message')}</Text>
+      </Stack>
+    );
+  }
+  return (
+    <>
+      <Drawer
+        opened={opened}
+        trapFocus={false}
+        onClose={() => setOpened(false)}
+        padding="xl"
+        position="right"
+        size="full"
+        transition="pop"
+        title={
+          <ContainerActionBar
+            selected={selection}
+            reload={() => {
+              refetch();
+              setSelection([]);
+            }}
+          />
+        }
+        styles={{
+          drawer: {
+            display: 'flex',
+            flexDirection: 'column',
+          },
+          body: {
+            minHeight: 0,
+          },
+        }}
+      >
+        <DockerTable
+          hideSearchBar={false}
+          widgetMode={false}
+          containers={data.data}
+          selection={selection}
+          setSelection={setSelection}
+        />
+      </Drawer>
+      <DockerTable
+        containers={data.data}
+        selection={[]}
+        setSelection={setSelection}
+        hideSearchBar={hideSearchBar}
+        widgetMode
+      />
+      {!isEditMode && (
+        <ActionIcon
+          size="md"
+          radius="md"
+          variant="light"
+          pos="absolute"
+          top={8}
+          right={8}
+          onClick={() => setOpened(true)}
+        >
+          <IconArrowsMaximize />
+        </ActionIcon>
+      )}
+    </>
+  );
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -9,6 +9,7 @@ import torrent from './torrent/TorrentTile';
 import usenet from './useNet/UseNetTile';
 import videoStream from './video/VideoStreamTile';
 import weather from './weather/WeatherTile';
+import docker from './docker/DockerTile';
 
 export default {
   calendar,
@@ -22,4 +23,5 @@ export default {
   'video-stream': videoStream,
   iframe,
   'media-server': mediaServer,
+  docker,
 };


### PR DESCRIPTION
# What it does
- Remove docker as a module
- Make it a widget (can be opened full screen with button or `mod + B`
- useQuery hook for caching with a stale time of one minute. The refresh button always refetches.

# Question
## Header mode
How do we make it so that we can still use the docker integration in full screen from the header ?
Some people might miss it. I was thinking about widget option that would just not render the main module component. This is possible since now we get the widget's option on load. 

## Custom right click menu
It would be a good idea to add a custom right click menu in the widget-form (not full screen) so we can start/stop a container right away 

# TODO 
Translation file for the widget itself

#Video  

https://user-images.githubusercontent.com/49837342/222626305-9bda4058-d500-467c-be15-db3d978e672c.mov

