### PR TITLE
✨ Add console warn if apps are missing properties

### DIFF
--- a/src/tools/config/getFrontendConfig.ts
+++ b/src/tools/config/getFrontendConfig.ts
@@ -7,6 +7,22 @@ export const getFrontendConfig = (name: string): ConfigType => {
   const config = getConfig(name);
 
   Consola.info(`Requested frontend content of configuration '${name}'`);
+  // Find out if config as apps with integrations that have a property with no value or undefined
+  // If so, remove print an error using consola
+  // If not, return the config
+  const appsWithIntegrationsWithUndefinedProperties = config.apps.filter(
+    (app) =>
+      app.integration?.properties.some(
+        (property) => property.value === null || property.value === undefined
+      ) ?? false
+  );
+  if (appsWithIntegrationsWithUndefinedProperties.length > 0) {
+    Consola.warn(
+      `The following apps have integrations with errored properties: [${appsWithIntegrationsWithUndefinedProperties
+        .map((app) => app.name)
+        .join(', ')}] please input the correct secrets once again for the concerned app(s), save them, exit edit mode and reload the page.`
+    );
+  }
 
   return {
     ...config,

--- a/src/tools/config/getFrontendConfig.ts
+++ b/src/tools/config/getFrontendConfig.ts
@@ -7,18 +7,16 @@ export const getFrontendConfig = (name: string): ConfigType => {
   const config = getConfig(name);
 
   Consola.info(`Requested frontend content of configuration '${name}'`);
-  // Find out if config as apps with integrations that have a property with no value or undefined
-  // If so, remove print an error using consola
   // If not, return the config
-  const appsWithIntegrationsWithUndefinedProperties = config.apps.filter(
+  const someAppsWithoutProps = config.apps.filter(
     (app) =>
       app.integration?.properties.some(
         (property) => property.value === null || property.value === undefined
       ) ?? false
   );
-  if (appsWithIntegrationsWithUndefinedProperties.length > 0) {
+  if (someAppsWithoutProps.length > 0) {
     Consola.warn(
-      `The following apps have integrations with errored properties: [${appsWithIntegrationsWithUndefinedProperties
+      `There are apps that have missing configuration options: [${someAppsWithoutProps
         .map((app) => app.name)
         .join(', ')}] please input the correct secrets once again for the concerned app(s), save them, exit edit mode and reload the page.`
     );

--- a/src/tools/config/getFrontendConfig.ts
+++ b/src/tools/config/getFrontendConfig.ts
@@ -18,7 +18,9 @@ export const getFrontendConfig = (name: string): ConfigType => {
     Consola.warn(
       `There are apps that have missing configuration options: [${someAppsWithoutProps
         .map((app) => app.name)
-        .join(', ')}] please input the correct secrets once again for the concerned app(s), save them, exit edit mode and reload the page.`
+        .join(
+          ', '
+        )}] please input the correct secrets once again for the concerned app(s), save them, exit edit mode and reload the page.`
     );
   }
 


### PR DESCRIPTION
If some apps properties in the config are missing a `value` field or have it set to nothing, it will create a warn in the server console (the docker logs)

<img width="851" alt="image" src="https://user-images.githubusercontent.com/49837342/226100073-04dc035b-9b6f-44ab-8f86-dfd4ec580916.png">