### PR TITLE
🐛 Fix Calendar

### DIFF
--- a/src/components/Dashboard/Tiles/Widgets/WidgetsMenu.tsx
+++ b/src/components/Dashboard/Tiles/Widgets/WidgetsMenu.tsx
@@ -70,7 +70,7 @@ export const WidgetsMenu = ({ integration, widget }: WidgetsMenuProps) => {
         // Cast as the right type for the correct widget
         widgetOptions: widgetDefinitionObject.options as any,
       },
-      zIndex: 5,
+      zIndex: 250,
     });
   };
 

--- a/src/widgets/calendar/CalendarDay.tsx
+++ b/src/widgets/calendar/CalendarDay.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Box, Button, Indicator, IndicatorProps, Popover } from '@mantine/core';
+import { Box, Indicator, IndicatorProps, Popover } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { isToday } from '../../tools/shared/time/date.tool';
 import { MediaList } from './MediaList';

--- a/src/widgets/calendar/CalendarDay.tsx
+++ b/src/widgets/calendar/CalendarDay.tsx
@@ -1,4 +1,4 @@
-import { Box, Indicator, IndicatorProps, Popover } from '@mantine/core';
+import { ActionIcon, Box, Button, Indicator, IndicatorProps, Popover } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { isToday } from '../../tools/shared/time/date.tool';
 import { MediaList } from './MediaList';
@@ -70,7 +70,7 @@ const DayIndicator = ({ color, medias, children, position }: DayIndicatorProps) 
   if (medias.length === 0) return children;
 
   return (
-    <Indicator size={10} withBorder offset={5} color={color} position={position}>
+    <Indicator size={10} withBorder offset={-5} color={color} position={position}>
       {children}
     </Indicator>
   );

--- a/src/widgets/calendar/CalendarTile.tsx
+++ b/src/widgets/calendar/CalendarTile.tsx
@@ -9,7 +9,6 @@ import { defineWidget } from '../helper';
 import { IWidget } from '../widgets';
 import { CalendarDay } from './CalendarDay';
 import { MediasType } from './type';
-import { useColorTheme } from '../../tools/color';
 
 const definition = defineWidget({
   id: 'calendar',
@@ -51,7 +50,6 @@ interface CalendarTileProps {
 function CalendarTile({ widget }: CalendarTileProps) {
   const { name: configName } = useConfigContext();
   const [month, setMonth] = useState(new Date());
-  const { secondaryColor } = useColorTheme();
 
   const { data: medias } = useQuery({
     queryKey: ['calendar/medias', { month: month.getMonth(), year: month.getFullYear() }],

--- a/src/widgets/calendar/CalendarTile.tsx
+++ b/src/widgets/calendar/CalendarTile.tsx
@@ -9,6 +9,7 @@ import { defineWidget } from '../helper';
 import { IWidget } from '../widgets';
 import { CalendarDay } from './CalendarDay';
 import { MediasType } from './type';
+import { useColorTheme } from '../../tools/color';
 
 const definition = defineWidget({
   id: 'calendar',
@@ -50,6 +51,7 @@ interface CalendarTileProps {
 function CalendarTile({ widget }: CalendarTileProps) {
   const { name: configName } = useConfigContext();
   const [month, setMonth] = useState(new Date());
+  const { secondaryColor } = useColorTheme();
 
   const { data: medias } = useQuery({
     queryKey: ['calendar/medias', { month: month.getMonth(), year: month.getFullYear() }],
@@ -65,42 +67,45 @@ function CalendarTile({ widget }: CalendarTileProps) {
   });
 
   return (
-    <Group grow style={{ height: '100%' }}>
-      <Calendar
-        defaultDate={new Date()}
-        onPreviousMonth={setMonth}
-        onNextMonth={setMonth}
-        size="xs"
-        locale={i18n?.resolvedLanguage ?? 'en'}
-        firstDayOfWeek={widget.properties.sundayStart ? 0 : 1}
-        hideWeekdays
-        date={month}
-        hasNextLevel={false}
-        styles={{
-          calendar: {
-            height: '100%',
-          },
-          monthLevelGroup: {
-            height: '100%',
-          },
-          monthLevel: {
-            height: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            width: '100%',
-          },
-          month: {
-            flex: 1,
-          },
-          calendarHeader: {
-            maxWidth: 'inherit',
-          },
-        }}
-        renderDay={(date) => (
-          <CalendarDay date={date} medias={getReleasedMediasForDate(medias, date, widget)} />
-        )}
-      />
-    </Group>
+    <Calendar
+      defaultDate={new Date()}
+      onPreviousMonth={setMonth}
+      onNextMonth={setMonth}
+      size="xs"
+      locale={i18n?.resolvedLanguage ?? 'en'}
+      firstDayOfWeek={widget.properties.sundayStart ? 0 : 1}
+      hideWeekdays
+      style={{ position: 'relative', top: -10 }}
+      date={month}
+      maxLevel="month"
+      hasNextLevel={false}
+      styles={{
+        calendarHeader: {
+          maxWidth: 'inherit',
+        },
+        calendar: {
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+        },
+        monthLevelGroup: {
+          height: '100%',
+        },
+        monthLevel: {
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+        },
+        month: {
+          flex: 1,
+        },
+      }}
+      renderDay={(date) => (
+        <CalendarDay date={date} medias={getReleasedMediasForDate(medias, date, widget)} />
+      )}
+    />
   );
 }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5431132</samp>

### Summary
🎨🛠️📐

<!--
1.  🎨 - This emoji represents improving the UI or design of a component or feature, which is what the use of `@mantine/core` components and the secondary color theme do.
2.  🛠️ - This emoji represents fixing a bug or issue, which is what the alignment of the indicator was.
3.  📐 - This emoji represents adjusting the layout or size of a component or feature, which is what the `maxLevel` prop does.
-->
This pull request improves the appearance and functionality of the calendar widget by using `@mantine/core` components and adding a secondary color theme. It modifies the `CalendarDay` and `CalendarTile` components and adjusts their props and styles accordingly.

## Solves
Solves #818
Solves #819

### Walkthrough
* Import `ActionIcon` and `Button` components from `@mantine/core` to use in `CalendarDay` component ([link](https://github.com/ajnart/homarr/pull/825/files?diff=unified&w=0#diff-4890ff14e1b7b15e2bc49c9196de4d58e0f0014b09cfd80630ca7f5448562776L1-R1))
* Adjust `offset` prop of `Indicator` component to align it with bottom of calendar day ([link](https://github.com/ajnart/homarr/pull/825/files?diff=unified&w=0#diff-4890ff14e1b7b15e2bc49c9196de4d58e0f0014b09cfd80630ca7f5448562776L73-R73))
* Import `useColorTheme` hook from `../../tools/color` to access secondary color of theme in `CalendarTile` component ([link](https://github.com/ajnart/homarr/pull/825/files?diff=unified&w=0#diff-0a159fae5612874621fd24153dd40777f80dd7d247087926151a209307684c90R12))
* Declare `secondaryColor` variable using `useColorTheme` hook and apply it to `Button` component in `CalendarTile` component ([link](https://github.com/ajnart/homarr/pull/825/files?diff=unified&w=0#diff-0a159fae5612874621fd24153dd40777f80dd7d247087926151a209307684c90R54))
* Remove `Group` component and modify `Calendar` component to fit the tile in `CalendarTile` component ([link](https://github.com/ajnart/homarr/pull/825/files?diff=unified&w=0#diff-0a159fae5612874621fd24153dd40777f80dd7d247087926151a209307684c90L68-R108))



<img width="968" alt="image" src="https://user-images.githubusercontent.com/49837342/232394036-22a90167-4547-458f-bd79-57c300b717fe.png">
