### PR TITLE
✨Allow Video Stream widget to play any video file type.

### DIFF
--- a/src/widgets/video/VideoFeed.tsx
+++ b/src/widgets/video/VideoFeed.tsx
@@ -2,6 +2,7 @@ import { createStyles, LoadingOverlay } from '@mantine/core';
 import { useEffect, useRef, useState } from 'react';
 import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
+
 interface VideoFeedProps {
   source: string;
   muted: boolean;
@@ -48,7 +49,7 @@ const VideoFeed = ({ source, controls, autoPlay, muted }: VideoFeedProps) => {
       <LoadingOverlay visible={player === undefined} />
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video className={cx('video-js', classes.video)} ref={videoRef}>
-        <source src={source}/>
+        <source src={source} />
       </video>
     </>
   );

--- a/src/widgets/video/VideoFeed.tsx
+++ b/src/widgets/video/VideoFeed.tsx
@@ -2,7 +2,6 @@ import { createStyles, LoadingOverlay } from '@mantine/core';
 import { useEffect, useRef, useState } from 'react';
 import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
-
 interface VideoFeedProps {
   source: string;
   muted: boolean;
@@ -15,7 +14,6 @@ const VideoFeed = ({ source, controls, autoPlay, muted }: VideoFeedProps) => {
   const [player, setPlayer] = useState<ReturnType<typeof videojs>>();
 
   const { classes, cx } = useStyles();
-
   useEffect(() => {
     // make sure Video.js player is only initialized once
     if (player) {
@@ -50,7 +48,7 @@ const VideoFeed = ({ source, controls, autoPlay, muted }: VideoFeedProps) => {
       <LoadingOverlay visible={player === undefined} />
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video className={cx('video-js', classes.video)} ref={videoRef}>
-        <source src={source} type="video/mp4" />
+        <source src={source}/>
       </video>
     </>
   );


### PR DESCRIPTION
This allows the video player to play any video source, including m3u8 live streams, mp4, gifs, etc.

*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
> One of: Bugfix or Feature (Depending on how you view it)

### Overview
> This change allows the video on a Video Stream widget to be any type of video file. Including gif, mp4, or even m3u8 live streams


### Screenshot _(if applicable)_
> Here is a before and after video showing the change not just working with new video types, but also does not break past functionality.

Before:

https://user-images.githubusercontent.com/39219859/232852017-28107601-2e3f-4930-a280-80e12b8fda67.mp4

After:

https://user-images.githubusercontent.com/39219859/232852084-5bb0afe1-961f-46ef-ac59-d57afc0f7314.mp4


