### PR TITLE
💄 Fix max iframe width

### DIFF
--- a/src/widgets/iframe/IFrameTile.tsx
+++ b/src/widgets/iframe/IFrameTile.tsx
@@ -55,7 +55,7 @@ function IFrameTile({ widget }: IFrameTileProps) {
   }
 
   return (
-    <Container h="100%" w="100%" p={0}>
+    <Container h="100%" w="100%" maw="initial" mah="initial" p={0}>
       <iframe
         className={classes.iframe}
         src={widget.properties.embedUrl}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f4db55</samp>

### Summary
🖼️📏🔄

<!--
1.  🖼️ - This emoji represents the iframe element, which is used to display web content in a tile.
2.  📏 - This emoji represents the max-width and max-height properties, which control how large the iframe can grow in relation to its container.
3.  🔄 - This emoji represents the initial value, which resets the max-width and max-height to their default values, which depend on the content and the context of the iframe.
-->
Fixed iframe cropping issue in `IFrameTile` component by setting max-width and max-height to `initial`.

> _`Container` adapts_
> _With `maw` and `mah` props set_
> _Iframe fills the tile_

### Walkthrough
*  Override max-width and max-height styles for iframe container ([link](https://github.com/ajnart/homarr/pull/851/files?diff=unified&w=0#diff-c88d3d0343f0e2bed0804ceb365a31f9ec8bdb2c7e771c7c4647be9e9084ef0bL58-R58)) to prevent cropping and allow iframe to fill tile space

