### PR TITLE
🚨 Fix runtime zustand warnings for imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "xml-js": "^1.6.11",
     "yarn": "^1.22.19",
     "zod": "^3.21.4",
-    "zustand": "^4.1.4"
+    "zustand": "^4.3.7"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^12.1.4",

--- a/src/config/provider.tsx
+++ b/src/config/provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
-import shallow from 'zustand/shallow';
+import { shallow } from 'zustand/shallow';
 import { useColorTheme } from '../tools/color';
 import { ConfigType } from '../types/config';
 import { useConfigStore } from './store';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5002,7 +5002,7 @@ __metadata:
     xml-js: ^1.6.11
     yarn: ^1.22.19
     zod: ^3.21.4
-    zustand: ^4.1.4
+    zustand: ^4.3.7
   languageName: unknown
   linkType: soft
 
@@ -8943,9 +8943,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.1.4":
-  version: 4.3.6
-  resolution: "zustand@npm:4.3.6"
+"zustand@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "zustand@npm:4.3.7"
   dependencies:
     use-sync-external-store: 1.2.0
   peerDependencies:
@@ -8956,6 +8956,6 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 4d3cec03526f04ff3de6dc45b6f038c47f091836af9660fbf5f682cae1628221102882df20e4048dfe699a43f67424e5d6afc1116f3838a80eea5dd4f95ddaed
+  checksum: 355b414ba4830b6106bcb888077c5f90f40ed649e4127e337eff4fb4ea90e88bf5cccf32344711d743cb92a676a0643a6ab3674ddc60ed49f17ea1bc8e3f58e2
   languageName: node
   linkType: hard


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4f9f6fe</samp>

### Summary
🐛🔄🧹

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes a TypeScript error that prevented the code from compiling correctly.
2.  🔄 - This emoji represents a refactor, since the change improves the code style and consistency without changing the functionality or behavior of the code.
3.  🧹 - This emoji represents a cleanup, since the change removes an unnecessary or redundant import syntax that could cause confusion or errors.
-->
Fixed a TypeScript error in `src/config/provider.tsx` by using a named import for `shallow` from `zustand/shallow`. This improves the consistency and correctness of the code.

> _`shallow` import changed_
> _no default export in module_
> _TypeScript error gone_

### Walkthrough
* Change the import of `shallow` to use a named import instead of a default import ([link](https://github.com/ajnart/homarr/pull/853/files?diff=unified&w=0#diff-e3247ac5e976dd37bb6f4c964ef0ce4797d8857743e439d091b84f234273afbfL2-R2))

