### PR TITLE
🐛 Make color picker prioritize config colors

### DIFF
--- a/src/components/Settings/Customization/Theme/ColorSelector.tsx
+++ b/src/components/Settings/Customization/Theme/ColorSelector.tsx
@@ -21,10 +21,13 @@ interface ColorControlProps {
 
 export function ColorSelector({ type, defaultValue }: ColorControlProps) {
   const { t } = useTranslation('settings/customization/color-selector');
-  const [color, setColor] = useState(defaultValue);
+  const { config, name: configName } = useConfigContext();
+  const [color, setColor] =
+    type === 'primary'
+      ? useState(config?.settings.customization.colors.primary || defaultValue)
+      : useState(config?.settings.customization.colors.secondary || defaultValue);
   const [popoverOpened, popover] = useDisclosure(false);
   const { setPrimaryColor, setSecondaryColor } = useColorTheme();
-  const { config, name: configName } = useConfigContext();
   const updateConfig = useConfigStore((x) => x.updateConfig);
 
   const theme = useMantineTheme();


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Bugfix

### Overview
When going to customization settings, the colors for Primary and Secondary colors are the default colors on refresh. With this fix it ensures that it sets itself to the colors in the config.


### Screenshot _(if applicable)_
**Before**

https://user-images.githubusercontent.com/39219859/234403975-bd28f84c-78ec-476c-92c8-709317ed8198.mp4

**After**

https://user-images.githubusercontent.com/39219859/234404037-c04fcf29-8ecb-4668-91e8-e11cc9adb2b9.mp4

