### PR TITLE
🐛 Add ipv6 support for url regex

### DIFF
--- a/src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx
@@ -25,7 +25,7 @@ import { DebouncedAppIcon } from './Tabs/Shared/DebouncedAppIcon';
 import { EditAppModalTab } from './Tabs/type';
 
 const appUrlRegex =
-  '(https?://(?:www.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\\s]{2,}|https?://(?:www.|(?!www))[a-zA-Z0-9]+.[^\\s]{2,}|www.[a-zA-Z0-9]+.[^\\s]{2,})';
+  '(https?://(?:www.|(?!www))\\[?[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\]?.[^\\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\\s]{2,}|https?://(?:www.|(?!www))\\[?[a-zA-Z0-9]+\\]?.[^\\s]{2,}|www.[a-zA-Z0-9]+.[^\\s]{2,})';
 
 export const EditAppModal = ({
   context,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 918768a</samp>

### Summary
🐛🌐🛠️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. The app URL validation was not working correctly for IPv6 addresses, so this emoji conveys that the change fixes a problem that was affecting the functionality of the component.
2.  🌐 - This emoji represents the internet or web, which is the domain of the change. The app URL is a web address that identifies the app, and the change affects how the component handles different formats of web addresses, such as IPv6. This emoji conveys that the change is related to the web or internet aspect of the component.
3.  🛠️ - This emoji represents a tool or improvement, which is the secondary effect of the change. The app URL validation is now more robust and flexible, and can handle a wider range of web addresses. This emoji conveys that the change enhances the quality or performance of the component.
-->
Fixed app URL validation for IPv6 addresses in `EditAppModal`. Modified `appUrlRegex` constant in `src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx` to allow square brackets in the domain name.

> _`appUrlRegex` changed_
> _Square brackets for IPv6_
> _Winter of bug fix_

### Walkthrough
* Allow square brackets in app URL validation to support IPv6 addresses ([link](https://github.com/ajnart/homarr/pull/864/files?diff=unified&w=0#diff-5244b03a1c8dcff10f0cbb0ac099b372b14672874f981553b3e4b3443d041b79L28-R28))

