### PR TITLE
✨ Add more iFrame attributes

### DIFF
--- a/src/widgets/iframe/IFrameTile.tsx
+++ b/src/widgets/iframe/IFrameTile.tsx
@@ -22,6 +22,34 @@ const definition = defineWidget({
       type: 'switch',
       defaultValue: false,
     },
+    allowScrolling: {
+      type: 'switch',
+      defaultValue: true,
+    },
+    allowTransparency: {
+      type: 'switch',
+      defaultValue: false,
+    },
+    allowPayment: {
+      type: 'switch',
+      defaultValue: false,
+    },
+    allowAutoPlay: {
+      type: 'switch',
+      defaultValue: false,
+    },
+    allowMicrophone: {
+      type: 'switch',
+      defaultValue: false,
+    },
+    allowCamera: {
+      type: 'switch',
+      defaultValue: false,
+    },
+    allowGeolocation: {
+      type: 'switch',
+      defaultValue: false,
+    },
   },
   component: IFrameTile,
 });
@@ -54,13 +82,43 @@ function IFrameTile({ widget }: IFrameTileProps) {
     );
   }
 
+  const allowedPermissions: string[] = [];
+
+  if (widget.properties.allowTransparency) {
+    allowedPermissions.push('transparency');
+  }
+
+  if (widget.properties.allowFullScreen) {
+    allowedPermissions.push('fullscreen');
+  }
+
+  if (widget.properties.allowPayment) {
+    allowedPermissions.push('payment');
+  }
+
+  if (widget.properties.allowAutoPlay) {
+    allowedPermissions.push('autoplay');
+  }
+
+  if (widget.properties.allowCamera) {
+    allowedPermissions.push('camera');
+  }
+
+  if (widget.properties.allowMicrophone) {
+    allowedPermissions.push('microphone');
+  }
+
+  if (widget.properties.allowGeolocation) {
+    allowedPermissions.push('geolocation');
+  }
+
   return (
     <Container h="100%" w="100%" maw="initial" mah="initial" p={0}>
       <iframe
         className={classes.iframe}
         src={widget.properties.embedUrl}
         title="widget iframe"
-        allowFullScreen={widget.properties.allowFullScreen}
+        allow={allowedPermissions.join(' ')}
       >
         <Text>Your Browser does not support iframes. Please update your browser.</Text>
       </iframe>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0d46caf</samp>

### Summary
🛠️📝🖼️

<!--
1.  🛠️ - This emoji represents the addition of new features or functionality, which is what the new switch properties and the `allow` attribute do.
2.  📝 - This emoji represents the update or improvement of documentation, which is what the doc comments for the new properties do.
3.  🖼️ - This emoji represents the enhancement or refinement of the user interface, which is what the new switches in the widget editor do.
-->
Add permission switches and `allow` attribute to `IFrameTile` widget. This lets the user customize the security and functionality of the embedded iframe in the dashboard.

> _Oh we are the coders of the `IFrameTile`_
> _We make it more flexible with every compile_
> _We add some switch properties to set the permissions_
> _And use the `allow` attribute for the iframe conditions_

### Walkthrough
*  Add new properties to IFrameTile widget to configure iframe permissions ([link](https://github.com/ajnart/homarr/pull/869/files?diff=unified&w=0#diff-c88d3d0343f0e2bed0804ceb365a31f9ec8bdb2c7e771c7c4647be9e9084ef0bR25-R52))
*  Create allowedPermissions array to store the enabled permissions for the iframe ([link](https://github.com/ajnart/homarr/pull/869/files?diff=unified&w=0#diff-c88d3d0343f0e2bed0804ceb365a31f9ec8bdb2c7e771c7c4647be9e9084ef0bR85-R114))
*  Set the allow attribute of the iframe element to the joined string of allowedPermissions ([link](https://github.com/ajnart/homarr/pull/869/files?diff=unified&w=0#diff-c88d3d0343f0e2bed0804ceb365a31f9ec8bdb2c7e771c7c4647be9e9084ef0bL63-R121))

