### PR TITLE
🐛 Overseerr air date undefined crash

### DIFF
--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -67,7 +67,7 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
               />
               <Stack spacing={0}>
                 <Group spacing="xs">
-                  <Text>{item.airDate.split('-')[0]}</Text>
+                  {item.airDate && <Text>{item.airDate.split('-')[0]}</Text>}
                   <MediaRequestStatusBadge status={item.status} />
                 </Group>
                 <Text

--- a/src/widgets/media-requests/media-request-types.tsx
+++ b/src/widgets/media-requests/media-request-types.tsx
@@ -8,7 +8,7 @@ export type MediaRequest = {
   userName: string;
   userProfilePicture: string;
   userLink: string;
-  airDate: string;
+  airDate?: string;
   status: MediaRequestStatus;
   backdropPath: string;
   posterPath: string;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf0b3f1</samp>

### Summary
🐛📝🎞️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of these changes. Both changes are related to fixing the issue of displaying media requests without an `airDate`.
2.  📝 - This emoji represents a documentation update, which is the secondary purpose of these changes. The first change modifies the type definition of the `MediaRequest` interface, which is part of the documentation of the code. The second change does not directly affect the documentation, but it could be considered a minor improvement of the readability of the code.
3.  🎞️ - This emoji represents a media-related change, which is the domain of these changes. Both changes are related to the media request feature, which involves displaying information about different types of media, such as movies, shows, or books.
-->
The pull request fixes a bug that caused errors when displaying media requests without an `airDate`. It makes the `airDate` property optional in the `MediaRequest` interface and adds a conditional rendering of the `Text` component in `MediaRequestListTile.tsx`.

> _`MediaRequest`_
> _air date may not exist_
> _handle gracefully_

### Walkthrough
*  Make `airDate` property optional in `MediaRequest` interface to handle media requests without a date ([link](https://github.com/ajnart/homarr/pull/936/files?diff=unified&w=0#diff-81cd1763c93a468c9e483cd5ba899f378bd6b65100084713df70c9f78b3c5cffL11-R11))
*  Add conditional rendering of `Text` component to avoid errors when `airDate` is undefined or null in `MediaRequestListTile.tsx` ([link](https://github.com/ajnart/homarr/pull/936/files?diff=unified&w=0#diff-d4e1fbb078f6effb9a447121330f078878aa135493bdc92d921f32b37cd66b13L70-R70))

