### PR TITLE
💄 Fix scrollbar bookmark widget

### DIFF
--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -29,6 +29,7 @@ import { z } from 'zod';
 import { IconSelector } from '../../components/IconSelector/IconSelector';
 import { defineWidget } from '../helper';
 import { IDraggableEditableListInputValue, IWidget } from '../widgets';
+import { useEditModeStore } from '../../components/Dashboard/Views/useEditModeStore';
 
 interface BookmarkItem {
   id: string;
@@ -175,14 +176,19 @@ interface BookmarkWidgetTileProps {
 function BookmarkWidgetTile({ widget }: BookmarkWidgetTileProps) {
   const { t } = useTranslation('modules/bookmark');
   const { classes } = useStyles();
+  const { enabled: isEditModeEnabled } = useEditModeStore();
 
   if (widget.properties.items.length === 0) {
     return (
       <Stack align="center">
         <IconPlaylistX />
         <Stack spacing={0}>
-          <Title order={5} align="center">{t('card.noneFound.title')}</Title>
-          <Text align="center" size="sm">{t('card.noneFound.text')}</Text>
+          <Title order={5} align="center">
+            {t('card.noneFound.title')}
+          </Title>
+          <Text align="center" size="sm">
+            {t('card.noneFound.text')}
+          </Text>
         </Stack>
       </Stack>
     );
@@ -191,7 +197,7 @@ function BookmarkWidgetTile({ widget }: BookmarkWidgetTileProps) {
   switch (widget.properties.layout) {
     case 'autoGrid':
       return (
-        <Box className={classes.grid} display="grid">
+        <Box className={classes.grid} display="grid" mr={isEditModeEnabled ? 'xl' : undefined}>
           {widget.properties.items.map((item: BookmarkItem, index) => (
             <Card
               className={classes.autoGridItem}
@@ -209,7 +215,12 @@ function BookmarkWidgetTile({ widget }: BookmarkWidgetTileProps) {
     case 'horizontal':
     case 'vertical':
       return (
-        <ScrollArea offsetScrollbars type="always" h="100%">
+        <ScrollArea
+          offsetScrollbars
+          type="always"
+          h="100%"
+          mr={isEditModeEnabled ? 'xl' : undefined}
+        >
           <Flex
             style={{ flexDirection: widget.properties.layout === 'vertical' ? 'column' : 'row' }}
             gap="md"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb3b36e</samp>

### Summary
🎨🪝🌟

<!--
1.  🎨 - This emoji is often used for changes related to styling, layout, or appearance of the UI. In this case, the margin-right property affects the spacing and alignment of the bookmark widget components.
2.  🪝 - This emoji is often used for changes related to hooks, custom or built-in, that provide state or logic to components. In this case, the `useEditModeStore` hook is used to access the edit mode state and conditionally apply the margin-right property.
3.  🌟 - This emoji is often used for changes related to code quality, readability, or refactoring. In this case, the code was reformatted for better readability and consistency.
-->
Added spacing for edit mode toolbar in `BookmarkWidgetTile` component. Used a custom hook to access the edit mode state and reformatted the code.

> _We're sailing on the web with our bookmark widgets_
> _We need some space to edit, so we add some margins_
> _We use a hook to check the mode, and then we style it_
> _We reformat all the code, to make it nice and tidy_

### Walkthrough
* Import the `useEditModeStore` hook to access the edit mode state ([link](https://github.com/ajnart/homarr/pull/957/files?diff=unified&w=0#diff-4e21db37dee41bb42ade14b19760cfcf743626a11ddfff6928dbce693bcb5e6eR32))
* Declare the `isEditModeEnabled` variable using the hook ([link](https://github.com/ajnart/homarr/pull/957/files?diff=unified&w=0#diff-4e21db37dee41bb42ade14b19760cfcf743626a11ddfff6928dbce693bcb5e6eR179))
* Add the `mr` property to the `Box` and `ScrollArea` components that wrap the bookmark widget layouts ([link](https://github.com/ajnart/homarr/pull/957/files?diff=unified&w=0#diff-4e21db37dee41bb42ade14b19760cfcf743626a11ddfff6928dbce693bcb5e6eL194-R200), [link](https://github.com/ajnart/homarr/pull/957/files?diff=unified&w=0#diff-4e21db37dee41bb42ade14b19760cfcf743626a11ddfff6928dbce693bcb5e6eL212-R223))
* Reformat the code for readability and consistency ([link](https://github.com/ajnart/homarr/pull/957/files?diff=unified&w=0#diff-4e21db37dee41bb42ade14b19760cfcf743626a11ddfff6928dbce693bcb5e6eL184-R191))

