### PR TITLE
🥅 Add widget backend error component

### DIFF
--- a/public/locales/en/widgets/error.json
+++ b/public/locales/en/widgets/error.json
@@ -1,0 +1,5 @@
+{
+  "title": "Unable to load data",
+  "text": "The widget was unable to load data. This error was most likely caused by bad configuration.",
+  "retry": "Retry"
+}

--- a/src/pages/api/modules/dns-hole/summary.ts
+++ b/src/pages/api/modules/dns-hole/summary.ts
@@ -22,6 +22,7 @@ export const Get = async (request: NextApiRequest, response: NextApiResponse) =>
     adsBlockedTodayPercentage: 0,
     dnsQueriesToday: 0,
     status: [],
+    errors: [],
   };
 
   const adsBlockedTodayPercentageArr: number[] = [];
@@ -73,8 +74,9 @@ export const Get = async (request: NextApiRequest, response: NextApiResponse) =>
           break;
         }
       }
-    } catch (err) {
+    } catch (err: any) {
       Consola.error(`Failed to communicate with DNS hole at ${app.url}: ${err}`);
+      data.errors.push(err.toString());
     }
   }
 

--- a/src/tools/server/translation-namespaces.ts
+++ b/src/tools/server/translation-namespaces.ts
@@ -43,6 +43,7 @@ export const dashboardNamespaces = [
   'modules/bookmark',
   'widgets/error-boundary',
   'widgets/draggable-list',
+  'widgets/error',
 ];
 
 export const loginNamespaces = ['authentication/login'];

--- a/src/widgets/dnshole/DnsHoleSummary.tsx
+++ b/src/widgets/dnshole/DnsHoleSummary.tsx
@@ -12,6 +12,8 @@ import { WidgetLoading } from '../loading';
 import { IWidget } from '../widgets';
 import { formatNumber } from '../../tools/client/math';
 import { useDnsHoleSummeryQuery } from './query';
+import { queryClient } from '../../tools/server/configurations/tanstack/queryClient.tool';
+import { GenericWidgetError } from '../error';
 
 const definition = defineWidget({
   id: 'dns-hole-summary',
@@ -39,10 +41,16 @@ interface DnsHoleSummaryWidgetProps {
 
 function DnsHoleSummaryWidgetTile({ widget }: DnsHoleSummaryWidgetProps) {
   const { t } = useTranslation('modules/dns-hole-summary');
-  const { isInitialLoading, data } = useDnsHoleSummeryQuery();
+  const { isInitialLoading, isError, error, data } = useDnsHoleSummeryQuery();
 
-  if (isInitialLoading || !data) {
+  if (isInitialLoading) {
     return <WidgetLoading />;
+  }
+
+  if (isError || !data || data.errors.length > 0) {
+    return (
+      <GenericWidgetError error={error || data?.errors} queryKeys={['dns-hole-control', 'dns-hole-summary']} />
+    );
   }
 
   return (

--- a/src/widgets/dnshole/type.ts
+++ b/src/widgets/dnshole/type.ts
@@ -7,6 +7,7 @@ export type AdStatistics = {
     status: PiholeApiSummaryType['status'],
     appId: string;
   }[];
+  errors: string[];
 };
 
 export type PiholeApiSummaryType = {

--- a/src/widgets/error.tsx
+++ b/src/widgets/error.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Button, Code, Stack, Text, Title } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { useTranslation } from 'next-i18next';
+import { queryClient } from '../tools/server/configurations/tanstack/queryClient.tool';
+
+interface GenericWidgetErrorProps {
+  queryKeys: string[];
+  error?: unknown | string[];
+}
+
+export const GenericWidgetError = ({ queryKeys, error }: GenericWidgetErrorProps) => {
+  const { t } = useTranslation('widgets/error');
+  const [isInvalidating, setIsInvalidating] = useState(false);
+  const invalidateAllKeys = async () => {
+    setIsInvalidating(true);
+    const promises = queryKeys.map((key) =>
+      queryClient.invalidateQueries({
+        queryKey: [key],
+      })
+    );
+
+    await Promise.all(promises);
+    setIsInvalidating(false);
+  };
+  return (
+    <Stack align="center">
+      <IconAlertTriangle />
+      <Stack spacing={0} align="center">
+        <Title order={4}>{t('title')}</Title>
+        <Text mb="sm">{t('text')}</Text>
+        {error && <ErrorDisplay error={error} />}
+      </Stack>
+      <Button onClick={invalidateAllKeys} loading={isInvalidating} variant="light" fullWidth>
+        {t('retry')}
+      </Button>
+    </Stack>
+  );
+};
+
+const ErrorDisplay = ({ error }: { error: any }) => {
+  if (Array.isArray(error)) {
+    return (
+      <Code w="100%" block>
+        {error.join('\n')}
+      </Code>
+    );
+  }
+
+  return (
+    <Code w="100%" block>
+      {error}
+    </Code>
+  );
+};


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1394fd1</samp>

### Summary
🌐🐛🚨

<!--
1.  🌐 - This emoji represents the addition of the 'widgets/error' namespace to the translation-namespaces.ts file, which enables the use of the translation strings for the generic widget error component. The globe emoji can symbolize the internationalization and localization of the application.
2.  🐛 - This emoji represents the addition of the errors property to the AdStatistics type in the type.ts file, which matches the data structure returned by the API endpoint and allows the use of the data.errors array in the widget component. The bug emoji can symbolize the fixing of a data mismatch issue and the improvement of the type safety of the application.
3.  🚨 - This emoji represents the addition of the GenericWidgetError component to the error.tsx file, the improvement of the error handling of the Get function in the summary.ts file, and the error handling and retry functionality of the DnsHoleSummary widget. The siren emoji can symbolize the alerting and handling of errors in the application and the enhancement of the user experience.
-->
This pull request enhances the error handling of the DnsHoleSummary widget and the API endpoint that provides its data. It adds an `errors` field to the data object, a GenericWidgetError component to display the errors, and a retry button to invalidate the data queries. It also updates the types and the translation namespaces to support the new component.

> _`GenericWidgetError`_
> _Displays and retries queries_
> _A helpful widget_

### Walkthrough
*  Add GenericWidgetError component to handle errors in widgets ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-59bb6add2481deb8e61c25e4720166ba2ce667ba207bcaeafc71ccaa9641c30eR1-R55))
*  Import GenericWidgetError and queryClient to DnsHoleSummary.tsx ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-6611cef73842042e401b8d9ac77a895d94a89d712a21810331c2c6190b91b535R15-R16))
*  Render GenericWidgetError component if useDnsHoleSummaryQuery hook returns errors ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-6611cef73842042e401b8d9ac77a895d94a89d712a21810331c2c6190b91b535L42-R55))
*  Add errors property to AdStatistics type to match API data structure ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-85469b11a3ec6c03343a25fb6da32fcf8410dc1491398d46c0ade500c2a5627fR10))
*  Add 'widgets/error' namespace to dashboardNamespaces array in `translation-namespaces.ts` ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-fafcb147bf52cc3ed5bed18b899ae103fb392b760c6c46cba10910a7eaa341acR46))
*  Initialize data with empty errors array in Get function of `src/pages/api/modules/dns-hole/summary.ts` ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-0d35b0423d8dc0d3351599d3d1a5dfdf14f89a7ca917369372f058c6fea739c8R25))
*  Push error message to data.errors array in catch block of Get function ([link](https://github.com/ajnart/homarr/pull/967/files?diff=unified&w=0#diff-0d35b0423d8dc0d3351599d3d1a5dfdf14f89a7ca917369372f058c6fea739c8L76-R79))

