### PR TITLE
💄 Fix video stream width

### DIFF
--- a/src/widgets/video/VideoFeed.tsx
+++ b/src/widgets/video/VideoFeed.tsx
@@ -58,6 +58,7 @@ const VideoFeed = ({ source, controls, autoPlay, muted }: VideoFeedProps) => {
 const useStyles = createStyles(({ radius }) => ({
   video: {
     height: '100%',
+    width: '100%',
     borderRadius: radius.md,
     overflow: 'hidden',
   },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at faecf3b</samp>

### Summary
📏📺📱

<!--
1.  📏 - This emoji can be used to represent the `width` property, which is related to measuring and sizing the video feed component.
2.  📺 - This emoji can be used to represent the video feed component itself, which is the main feature of the app and displays the live stream of the camera.
3.  📱 - This emoji can be used to represent the responsiveness and layout of the app, which is important for different screen sizes and devices.
-->
Added `width` property to `useStyles` hook in `VideoFeed.tsx` to improve video feed responsiveness and layout.

> _`width` fills the space_
> _video feed adapts well_
> _autumn leaves flutter_

### Walkthrough
*  Add `width` property to `useStyles` hook to make video feed component fill the available horizontal space ([link](https://github.com/ajnart/homarr/pull/968/files?diff=unified&w=0#diff-58e0e875d029e7e6e6671a50e031f3d2bd58b21c679eb8a5334dbde7e9e8443dR61))

