### PR TITLE
💄 Fix wrap of text for username in media server widget

### DIFF
--- a/src/widgets/media-server/TableRow.tsx
+++ b/src/widgets/media-server/TableRow.tsx
@@ -33,7 +33,7 @@ export const TableRow = ({ session, app }: TableRowProps) => {
                 {session.username?.at(0)?.toUpperCase()}
               </Avatar>
             )}
-            <Text>{session.username}</Text>
+            <Text style={{ whiteSpace: 'nowrap' }}>{session.username}</Text>
           </Flex>
         </td>
         <td>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa1a5d7</samp>

### Summary
📝📐🚫

<!--
1.  📝 - This emoji could be used to indicate that the text component was edited or modified.
2.  📐 - This emoji could be used to indicate that the layout or alignment of the component was adjusted or improved.
3.  🚫 - This emoji could be used to indicate that the text wrapping was prevented or disabled.
-->
Improved the layout of the media server table by preventing the session username from wrapping in `TableRow.tsx`.

> _`Text` component styled_
> _No wrapping for username_
> _Table rows aligned_

### Walkthrough
*  Prevent session username from wrapping in media server table ([link](https://github.com/ajnart/homarr/pull/1030/files?diff=unified&w=0#diff-45992951b82c5773169266ba140c3a8e115a6ad08e35f657c1bb03992ea5035dL36-R36))

