### PR TITLE
✨ Disable search focus on mobile

### DIFF
--- a/src/components/layout/header/Search.tsx
+++ b/src/components/layout/header/Search.tsx
@@ -171,7 +171,7 @@ export function Search() {
           <Autocomplete
             ref={textInput}
             onFocusCapture={() => setOpened(true)}
-            autoFocus
+            autoFocus={typeof window !== 'undefined' && window.innerWidth > 768}
             rightSection={<SearchModuleMenu />}
             placeholder={t(`searchEngines.${selectedSearchEngine.value}.description`) ?? undefined}
             value={searchQuery}


### PR DESCRIPTION
With this update the search will only be focused when above 768px screen width