### PR TITLE
🌐 Add language Galician

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -28,7 +28,8 @@ module.exports = {
       'sk',
       'no',
       'tr',
-      'lv'
+      'lv',
+      'gl'
     ],
 
     localeDetection: true,

--- a/src/tools/language.ts
+++ b/src/tools/language.ts
@@ -163,6 +163,12 @@ export const languages: Language[] = [
     translatedName: 'Latvian',
     emoji: '🇱🇻',
   },
+  {
+    shortName: 'gl',
+    originalName: 'Galego',
+    translatedName: 'Galician',
+    emoji: '🏴󠁥󠁳󠁧󠁡󠁿'
+  }
 ];
 
 export const getLanguageByCode = (code: string | null) =>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8e44414</samp>

### Summary
🌐🇬🇱➕

<!--
1.  🌐 This emoji represents the concept of internationalization and localization, as well as the web and the globe. It can be used to indicate that the web app supports multiple languages and regions.
2.  🇬🇱 This emoji is the flag of Greenland, which is the closest emoji to the flag of Galicia, a region in Spain where Galician is spoken. It can be used to identify the Galician language and culture, and to show respect for the diversity of the web app's users.
3.  ➕ This emoji represents the addition or inclusion of something new or positive. It can be used to indicate that the web app has expanded its features and functionality by adding a new language option.
-->
The pull request adds support for Galician as a new language option for the web app. It updates the `next-i18next.config.js` file and adds a new language object for Galician in the `src/tools/language.ts` file.

> _Adding `gl` language_
> _Galician joins the web app_
> _Autumn of cultures_

### Walkthrough
* Add 'gl' to the supported languages in the Next.js and next-i18next configuration ([link](https://github.com/ajnart/homarr/pull/1090/files?diff=unified&w=0#diff-fce332fdab5dc79594ac42cc8cd6114832222da4aac765842742fe1e0ddd0a55L31-R32))
* Define a language object for Galician with the short name, original name, translated name, and emoji flag ([link](https://github.com/ajnart/homarr/pull/1090/files?diff=unified&w=0#diff-4cc0eb2a1ae9d06682cd71027d2f25acba7164a21541d1dbcbaf07e6a15d000eR166-R171))

