### PR TITLE
💄 Rework the bookmark widget

### DIFF
--- a/public/locales/en/modules/bookmark.json
+++ b/public/locales/en/modules/bookmark.json
@@ -4,6 +4,12 @@
     "description": "Displays a static list of strings or links",
     "settings": {
       "title": "Bookmark settings",
+      "name": {
+        "label": "Widget Title",
+        "placeholder": {
+          "label" : "Leave empty to keep the title hidden"
+        }
+      },
       "items": {
         "label": "Items"
       },

--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -7,6 +7,7 @@ import {
   Group,
   Image,
   ScrollArea,
+  Divider,
   Stack,
   Switch,
   Text,
@@ -14,6 +15,7 @@ import {
   Title,
   createStyles,
   useMantineTheme,
+  InputProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import {
@@ -28,6 +30,7 @@ import { useTranslation } from 'next-i18next';
 import { useEffect } from 'react';
 import { v4 } from 'uuid';
 import { z } from 'zod';
+import React from 'react';
 
 import { useEditModeStore } from '../../components/Dashboard/Views/useEditModeStore';
 import { IconSelector } from '../../components/IconSelector/IconSelector';
@@ -47,6 +50,10 @@ const definition = defineWidget({
   id: 'bookmark',
   icon: IconBookmark,
   options: {
+    name: {
+      type: 'text',
+      defaultValue: '',
+    },
     items: {
       type: 'draggable-editable-list',
       defaultValue: [],
@@ -215,75 +222,92 @@ function BookmarkWidgetTile({ widget }: BookmarkWidgetTileProps) {
   switch (widget.properties.layout) {
     case 'autoGrid':
       return (
-        <Box className={classes.grid} mr={isEditModeEnabled ? 'xl' : undefined} h="100%">
-          {widget.properties.items.map((item: BookmarkItem, index) => (
-            <Card
-              className={classes.autoGridItem}
-              key={index}
-              px="xl"
-              radius="md"
-              component="a"
-              href={item.href}
-              target={item.openNewTab ? '_blank' : undefined}
-              withBorder
-              sx={{
-                backgroundColor: colorScheme === 'dark' ? colors.dark[5].concat('80') : colors.blue[0].concat('80'),
-                '&:hover': { backgroundColor: fn.primaryColor().concat('80'),}, //'40' = 25% opacity
-                flex:'1 1 auto',
-              }}
-              display="flex"
-            >
-              <BookmarkItemContent item={item} />
-            </Card>
-          ))}
-        </Box>
-      );
-    case 'horizontal':
-    case 'vertical':
-      return (
-        <ScrollArea
-          scrollbarSize={8}
-          type="auto"
-          h="100%"
-          mr={isEditModeEnabled ? 'xl' : undefined}
-          styles={{
-            viewport:{
-              //mantine being mantine again... this might break
-              '& div[style="min-width: 100%; display: table;"]':{
-                height:'100%',
-              },
-            },
-          }}
-        >
-          <Flex
-            style={{ flexDirection: widget.properties.layout === 'vertical' ? 'column' : 'row' }}
-            gap="0"
+        <Stack h="100%" spacing={0}>
+          <Title size="h4" px="0.25rem">{widget.properties.name}</Title>
+          <Box
+            className={classes.grid}
+            mr={isEditModeEnabled && widget.properties.name === "" ? 'xl' : undefined}
             h="100%"
           >
             {widget.properties.items.map((item: BookmarkItem, index) => (
               <Card
+                className={classes.autoGridItem}
                 key={index}
-                px="md"
-                py="0"
+                px="xl"
+                radius="md"
                 component="a"
                 href={item.href}
                 target={item.openNewTab ? '_blank' : undefined}
+                withBorder
+                bg={colorScheme === 'dark' ? colors.dark[5].concat('80') : colors.blue[0].concat('80')}
                 sx={{
-                  border:'0.1rem solid transparent',
-                  borderRadius:'0',
-                  borderBottomColor:(widget.properties.layout === 'vertical' && index < widget.properties.items.length - 1) ? '#343740' : 'transparent',
-                  borderRightColor:(widget.properties.layout === 'horizontal' && index < widget.properties.items.length - 1) ? '#343740' : 'transparent',
-                  backgroundColor: 'transparent',
-                  '&:hover': { backgroundColor: fn.primaryColor().concat('40'),}, //'40' = 25% opacity
-                  flex:'1 1 auto'
+                  '&:hover': { backgroundColor: fn.primaryColor().concat('40'), }, //'40' = 25% opacity
+                  flex:'1 1 auto',
                 }}
                 display="flex"
               >
-                <BookmarkItemContent item={item}/>
+                <BookmarkItemContent item={item} />
               </Card>
             ))}
-          </Flex>
-        </ScrollArea>
+          </Box>
+        </Stack>
+      );
+    case 'horizontal':
+    case 'vertical':
+      return (
+        <Stack h="100%" spacing={0}>
+          <Title size="h4" px="0.25rem">
+            {widget.properties.name}
+          </Title>
+          <ScrollArea
+            scrollbarSize={8}
+            type="auto"
+            h="100%"
+            offsetScrollbars
+            mr={isEditModeEnabled && widget.properties.name === ""? 'xl' : undefined}
+            styles={{
+              viewport:{
+                //mantine being mantine again... this might break. Needed for taking 100% of widget space
+                '& div[style="min-width: 100%; display: table;"]':{
+                  height:'100%',
+                },
+              },
+            }}
+          >
+            <Flex
+              direction={ widget.properties.layout === 'vertical' ? 'column' : 'row' }
+              gap="0"
+              h="100%"
+            >
+              {widget.properties.items.map((item: BookmarkItem, index) => (
+                <>
+                  <Divider
+                    m="1px"
+                    orientation={ widget.properties.layout !== 'vertical' ? 'vertical' : 'horizontal' } //Mantine doesn't let me refactor this, I tried
+                    hidden={!(index > 0)}
+                  />
+                  <Card
+                    key={index}
+                    px="md"
+                    py="1px"
+                    component="a"
+                    href={item.href}
+                    target={item.openNewTab ? '_blank' : undefined}
+                    radius="md"
+                    bg="transparent"
+                    sx={{
+                      '&:hover': { backgroundColor: fn.primaryColor().concat('40'),}, //'40' = 25% opacity
+                      flex:'1 1 auto'
+                    }}
+                    display="flex"
+                  >
+                    <BookmarkItemContent item={item}/>
+                  </Card>
+                </>
+              ))}
+            </Flex>
+          </ScrollArea>
+        </Stack>
       );
     default:
       return null;

--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -221,6 +221,7 @@ function BookmarkWidgetTile({ widget }: BookmarkWidgetTileProps) {
               className={classes.autoGridItem}
               key={index}
               px="xl"
+              radius="md"
               component="a"
               href={item.href}
               target={item.openNewTab ? '_blank' : undefined}

--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -44,6 +44,7 @@ interface BookmarkItem {
   iconUrl: string;
   openNewTab: boolean;
   hideHostname: boolean;
+  hideIcon: boolean;
 }
 
 const definition = defineWidget({
@@ -68,6 +69,7 @@ const definition = defineWidget({
           iconUrl: '/imgs/logo/logo.png',
           openNewTab: false,
           hideHostname: false,
+          hideIcon: false,
         };
       },
       itemComponent({ data, onChange, delete: deleteData }) {
@@ -144,6 +146,11 @@ const definition = defineWidget({
                 {...form.getInputProps('hideHostname')}
                 label="Hide Hostname"
                 checked={form.values.hideHostname}
+              />
+              <Switch
+                {...form.getInputProps('hideIcon')}
+                label="Hide Icon"
+                checked={form.values.hideIcon}
               />
               <Button
                 onClick={() => deleteData()}
@@ -318,7 +325,7 @@ const BookmarkItemContent = ({ item }: { item: BookmarkItem }) => {
   const { colorScheme } = useMantineTheme();
   return (
   <Group spacing="0rem 1rem">
-    <Image src={item.iconUrl} width={47} height={47} fit="contain" withPlaceholder />
+    <Image hidden={item.hideIcon} src={item.iconUrl} width={47} height={47} fit="contain" withPlaceholder />
     <Stack spacing={0}>
       <Text size="md">{item.name}</Text>
       <Text

--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -228,7 +228,9 @@ function BookmarkWidgetTile({ widget }: BookmarkWidgetTileProps) {
               sx={{
                 backgroundColor: colorScheme === 'dark' ? colors.dark[5].concat('80') : colors.blue[0].concat('80'),
                 '&:hover': { backgroundColor: fn.primaryColor().concat('80'),}, //'40' = 25% opacity
+                flex:'1 1 auto',
               }}
+              display="flex"
             >
               <BookmarkItemContent item={item} />
             </Card>

--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -40,7 +40,7 @@ interface BookmarkItem {
   href: string;
   iconUrl: string;
   openNewTab: boolean;
-  hideLink: boolean;
+  hideHostname: boolean;
 }
 
 const definition = defineWidget({
@@ -60,7 +60,7 @@ const definition = defineWidget({
           href: 'https://homarr.dev',
           iconUrl: '/imgs/logo/logo.png',
           openNewTab: false,
-          hideLink: false,
+          hideHostname: false,
         };
       },
       itemComponent({ data, onChange, delete: deleteData }) {
@@ -134,9 +134,9 @@ const definition = defineWidget({
                 checked={form.values.openNewTab}
               />
               <Switch
-                {...form.getInputProps('hideLink')}
-                label="Hide link"
-                checked={form.values.hideLink}
+                {...form.getInputProps('hideHostname')}
+                label="Hide Hostname"
+                checked={form.values.hideHostname}
               />
               <Button
                 onClick={() => deleteData()}
@@ -299,7 +299,7 @@ const BookmarkItemContent = ({ item }: { item: BookmarkItem }) => {
       <Text
         color={colorScheme === 'dark' ? "gray.6" : "gray.7"}
         size="sm"
-        hidden={item.hideLink}
+        hidden={item.hideHostname}
       >
         {new URL(item.href).hostname}
       </Text>

--- a/src/widgets/bookmark/BookmarkWidgetTile.tsx
+++ b/src/widgets/bookmark/BookmarkWidgetTile.tsx
@@ -325,7 +325,13 @@ const BookmarkItemContent = ({ item }: { item: BookmarkItem }) => {
   const { colorScheme } = useMantineTheme();
   return (
   <Group spacing="0rem 1rem">
-    <Image hidden={item.hideIcon} src={item.iconUrl} width={47} height={47} fit="contain" withPlaceholder />
+    <Image
+      hidden={item.hideIcon}
+      src={item.iconUrl}
+      width={47}
+      height={47}
+      fit="contain"
+      withPlaceholder />
     <Stack spacing={0}>
       <Text size="md">{item.name}</Text>
       <Text


### PR DESCRIPTION
### Category
> Cosmetic

### Overview
> Redesigned the bookmark widget:
> - Take less space per item.
> - Remove the bubble around each items in the vertical and horizontal option to prefer a simple line separator
> - Have the option to hide the Hostname.
> - Have the option to hide the Icon.
> - Completely fill the space available in the widget. (Thanks to @manuel-rw for battling mantine with me on that one)
> - Highlight currently hovered item using user primary shade (at 25% opacity to prevent overdoing it).

### Issue Number
> Closes #1035 

### Screenshot
> Grid using all the space available:
![image](https://github.com/ajnart/homarr/assets/26098587/9b3b4df8-cb3d-4ee7-82ad-d6ddba84573e)

> Vertical and horizontal underflow stretch:
![image](https://github.com/ajnart/homarr/assets/26098587/686b8f0d-6989-40d9-b871-7836e76a64a0)
![image](https://github.com/ajnart/homarr/assets/26098587/e6edd556-30d6-4c09-8c32-13b58068cd45)

> Vertical and horizontal overflows:
![image](https://github.com/ajnart/homarr/assets/26098587/16371f20-c1eb-4613-9539-37e98508e59f)
![image](https://github.com/ajnart/homarr/assets/26098587/d3833eeb-9737-4e3e-bb5a-1934acd27cbc)

> All images above also show the highlight function, light/dark theme variation and all links hidden except for radarr.


> Options Hide link
![image](https://github.com/ajnart/homarr/assets/26098587/a8a1f7b9-2d42-430d-9d9e-3e2d81d9f37b)
