### PR TITLE
✨ Allow non standard protocols for ext app URL

### DIFF
--- a/public/locales/en/layout/modals/add-app.json
+++ b/public/locales/en/layout/modals/add-app.json
@@ -24,7 +24,8 @@
 		"isOpeningNewTab": {
 			"label": "Open in new tab",
 			"description": "Open the app in a new tab instead of the current one."
-		}
+		},
+		"customProtocolWarning": "Using a non-standard protocol. This may require pre-installed applications and can introduce security risks. Ensure that your address is secure and trusted."
 	},
 	"network": {
 		"statusChecker": {

--- a/src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx
@@ -28,6 +28,9 @@ import { EditAppModalTab } from './Tabs/type';
 const appUrlRegex =
   '(https?://(?:www.|(?!www))\\[?[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\]?.[^\\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\\s]{2,}|https?://(?:www.|(?!www))\\[?[a-zA-Z0-9]+\\]?.[^\\s]{2,}|www.[a-zA-Z0-9]+.[^\\s]{2,})';
 
+const appUrlWithAnyProtocolRegex =
+  '([A-z]+://(?:www.|(?!www))\\[?[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\]?.[^\\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\\s]{2,}|[A-z]+://(?:www.|(?!www))\\[?[a-zA-Z0-9]+\\]?.[^\\s]{2,}|www.[a-zA-Z0-9]+.[^\\s]{2,})';
+
 export const EditAppModal = ({
   context,
   id,
@@ -71,8 +74,8 @@ export const EditAppModal = ({
             return null;
           }
 
-          if (!url.match(appUrlRegex)) {
-            return 'Uri override is not a valid uri';
+          if (!url.match(appUrlWithAnyProtocolRegex)) {
+            return 'External URI is not a valid uri';
           }
 
           return null;

--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/GeneralTab/GeneralTab.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/GeneralTab/GeneralTab.tsx
@@ -1,4 +1,4 @@
-import { Tabs, TextInput } from '@mantine/core';
+import { Tabs, Text, TextInput } from '@mantine/core';
 import { UseFormReturnType } from '@mantine/form';
 import { IconClick, IconCursorText, IconLink } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
@@ -22,6 +22,7 @@ export const GeneralTab = ({ form, openTab }: GeneralTabProps) => {
         placeholder="My example app"
         variant="default"
         withAsterisk
+        mb="md"
         {...form.getInputProps('name')}
       />
       <TextInput
@@ -31,10 +32,8 @@ export const GeneralTab = ({ form, openTab }: GeneralTabProps) => {
         placeholder="https://google.com"
         variant="default"
         withAsterisk
+        mb="md"
         {...form.getInputProps('url')}
-        onChange={(e) => {
-          form.setFieldValue('url', e.target.value);
-        }}
       />
       <TextInput
         icon={<IconClick size={16} />}
@@ -44,6 +43,13 @@ export const GeneralTab = ({ form, openTab }: GeneralTabProps) => {
         variant="default"
         {...form.getInputProps('behaviour.externalUrl')}
       />
+
+      {!form.values.behaviour.externalUrl.startsWith('https://') &&
+        !form.values.behaviour.externalUrl.startsWith('http://') && (
+          <Text color="red" mt="sm" size="sm">
+            {t('behaviour.customProtocolWarning')}
+          </Text>
+        )}
     </Tabs.Panel>
   );
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b557f04</samp>

### Summary
🖇️🎨⚠️

<!--
1.  🖇️ - This emoji can be used to represent the improved validation and error message for external URIs, as it suggests a link or connection between different sources or destinations. It can also imply that the app modal is more consistent and coherent with the expected format and behavior of external URIs.
2. 🎨 - This emoji can be used to represent the improved layout and validation of the `url` and `externalUrl` fields, as it suggests a visual enhancement or refinement of the user interface. It can also imply that the app modal is more aesthetically pleasing and user-friendly.
3. ⚠️ - This emoji can be used to represent the warning message for custom protocols in external URLs, as it suggests a potential risk or issue that the user should be aware of. It can also imply that the app modal is more informative and helpful in guiding the user to avoid errors or problems.
-->
Improved the user experience and functionality of editing apps with external URLs. Added validation, error messages, and warnings for different protocols in the `url` and `externalUrl` fields of the `EditAppModal` component.

> _Edit app modal_
> _`url` and `externalUrl`_
> _Warn of custom schemes_

### Walkthrough
*  Add a new regular expression constant to validate external URIs with any protocol ([link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-5244b03a1c8dcff10f0cbb0ac099b372b14672874f981553b3e4b3443d041b79R31-R33))
*  Change the `url` field validation to use the new constant and update the error message to say "External URI" ([link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-5244b03a1c8dcff10f0cbb0ac099b372b14672874f981553b3e4b3443d041b79L74-R78))
*  Import the `Text` component from `@mantine/core` to display a warning message for custom protocols ([link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-8bafd8e3809db3faca482250811bc81cdc1542951e62aa9c0853f6d7a3889800L1-R1))
*  Add bottom margins to the `name` and `url` fields to create some space between them and the next fields ([link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-8bafd8e3809db3faca482250811bc81cdc1542951e62aa9c0853f6d7a3889800R25), [link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-8bafd8e3809db3faca482250811bc81cdc1542951e62aa9c0853f6d7a3889800L34-R36))
*  Remove the redundant `onChange` handler for the `url` field ([link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-8bafd8e3809db3faca482250811bc81cdc1542951e62aa9c0853f6d7a3889800L34-R36))
*  Add a conditional `Text` component below the `externalUrl` field to display a warning message in red if the value does not start with http or https ([link](https://github.com/ajnart/homarr/pull/1210/files?diff=unified&w=0#diff-8bafd8e3809db3faca482250811bc81cdc1542951e62aa9c0853f6d7a3889800R46-R52))

