### PR TITLE
💄 Media requests stats widget stretch elements to fit tile

### DIFF
--- a/public/locales/en/modules/media-requests-stats.json
+++ b/public/locales/en/modules/media-requests-stats.json
@@ -3,7 +3,10 @@
     "name": "Media request stats",
     "description": "Statistics about your media requests",
     "settings": {
-      "title": "Media requests stats"
+      "title": "Media requests stats",
+      "direction": {
+        "label": "Direction of the layout."
+      }
     }
   },
   "stats": {

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -14,7 +14,7 @@ const definition = defineWidget({
   options: {
     direction: {
       type: 'select',
-      defaultValue: 'row',
+      defaultValue: 'horizontal',
       data: [
         { label: 'Horizontal', value: 'horizontal' },
         { label: 'Vertical', value: 'vertical' },

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -1,4 +1,4 @@
-import { Card, Center, Flex, Stack, Text } from '@mantine/core';
+import { Box, Card, createStyles, Flex, FlexProps, Stack, Text } from '@mantine/core';
 import { IconChartBar } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
 
@@ -11,14 +11,23 @@ import { MediaRequestStatus } from './media-request-types';
 const definition = defineWidget({
   id: 'media-requests-stats',
   icon: IconChartBar,
-  options: {},
-  component: MediaRequestStatsTile,
+  options: {
+    direction: {
+      type: 'select',
+      defaultValue: 'row',
+      data: [
+        { label: 'Horizontal', value: 'horizontal' },
+        { label: 'Vertical', value: 'vertical' },
+      ],
+    },
+  },
   gridstack: {
     minWidth: 1,
-    minHeight: 2,
+    minHeight: 1,
     maxWidth: 12,
     maxHeight: 12,
   },
+  component: MediaRequestStatsTile,
 });
 
 export type MediaRequestStatsWidget = IWidget<(typeof definition)['id'], typeof definition>;
@@ -36,38 +45,41 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
   }
 
   return (
-    <Flex gap="md" wrap="wrap">
-      <Card w={100} h={100} withBorder>
-        <Center h="100%">
-          <Stack spacing={0} align="center">
-            <Text>
-              {data.filter((x) => x.status === MediaRequestStatus.PendingApproval).length}
-            </Text>
-            <Text color="dimmed" align="center" size="xs">
-              {t('stats.pending')}
-            </Text>
-          </Stack>
-        </Center>
+    <Flex
+      w="100%"
+      h="100%"
+      gap="md"
+      direction={ widget.properties.direction != 'vertical' ? 'row' : 'column' }
+    >
+      <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
+        <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
+          <Text align="center">
+            {data.filter((x) => x.status === MediaRequestStatus.PendingApproval).length}
+          </Text>
+          <Text color="dimmed" align="center" size="xs">
+            {t('stats.pending')}
+          </Text>
+        </Stack>
       </Card>
-      <Card w={100} h={100} withBorder>
-        <Center h="100%">
-          <Stack spacing={0} align="center">
-            <Text align="center">{data.filter((x) => x.type === 'tv').length}</Text>
-            <Text color="dimmed" align="center" size="xs">
-              {t('stats.tvRequests')}
-            </Text>
-          </Stack>
-        </Center>
+      <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
+        <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
+          <Text align="center">
+            {data.filter((x) => x.type === 'tv').length}
+          </Text>
+          <Text color="dimmed" align="center" size="xs">
+            {t('stats.tvRequests')}
+          </Text>
+        </Stack>
       </Card>
-      <Card w={100} h={100} withBorder>
-        <Center h="100%">
-          <Stack spacing={0} align="center">
-            <Text align="center">{data.filter((x) => x.type === 'movie').length}</Text>
-            <Text color="dimmed" align="center" size="xs">
-              {t('stats.movieRequests')}
-            </Text>
-          </Stack>
-        </Center>
+      <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
+        <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
+          <Text align="center">
+            {data.filter((x) => x.type === 'movie').length}
+          </Text>
+          <Text color="dimmed" align="center" size="xs">
+            {t('stats.movieRequests')}
+          </Text>
+        </Stack>
       </Card>
     </Flex>
   );

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, createStyles, Flex, FlexProps, Stack, Text } from '@mantine/core';
+import { Card, Flex, Stack, Text } from '@mantine/core';
 import { IconChartBar } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
 
@@ -7,7 +7,6 @@ import { WidgetLoading } from '../loading';
 import { IWidget } from '../widgets';
 import { useMediaRequestQuery } from './media-request-query';
 import { MediaRequestStatus } from './media-request-types';
-import { string } from 'zod';
 
 const definition = defineWidget({
   id: 'media-requests-stats',

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -7,6 +7,7 @@ import { WidgetLoading } from '../loading';
 import { IWidget } from '../widgets';
 import { useMediaRequestQuery } from './media-request-query';
 import { MediaRequestStatus } from './media-request-types';
+import { string } from 'zod';
 
 const definition = defineWidget({
   id: 'media-requests-stats',
@@ -14,10 +15,10 @@ const definition = defineWidget({
   options: {
     direction: {
       type: 'select',
-      defaultValue: 'horizontal',
+      defaultValue: 'row' as 'row' | 'column',
       data: [
-        { label: 'Horizontal', value: 'horizontal' },
-        { label: 'Vertical', value: 'vertical' },
+        { label: 'Horizontal', value: 'row' },
+        { label: 'Vertical', value: 'column' },
       ],
     },
   },
@@ -49,40 +50,42 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
       w="100%"
       h="100%"
       gap="md"
-      direction={ widget.properties.direction != 'vertical' ? 'row' : 'column' }
+      direction={ widget.properties.direction?? 'row' }
     >
-      <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
-        <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
-          <Text align="center">
-            {data.filter((x) => x.status === MediaRequestStatus.PendingApproval).length}
-          </Text>
-          <Text color="dimmed" align="center" size="xs">
-            {t('stats.pending')}
-          </Text>
-        </Stack>
-      </Card>
-      <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
-        <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
-          <Text align="center">
-            {data.filter((x) => x.type === 'tv').length}
-          </Text>
-          <Text color="dimmed" align="center" size="xs">
-            {t('stats.tvRequests')}
-          </Text>
-        </Stack>
-      </Card>
-      <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
-        <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
-          <Text align="center">
-            {data.filter((x) => x.type === 'movie').length}
-          </Text>
-          <Text color="dimmed" align="center" size="xs">
-            {t('stats.movieRequests')}
-          </Text>
-        </Stack>
-      </Card>
+      <StatCard
+        number={data.filter((x) => x.status === MediaRequestStatus.PendingApproval).length}
+        label={t('stats.pending')}
+      />
+      <StatCard
+        number={data.filter((x) => x.type === 'tv').length}
+        label={t('stats.tvRequests')}
+      />
+      <StatCard
+        number={data.filter((x) => x.type === 'movie').length}
+        label={t('stats.movieRequests')}
+      />
     </Flex>
   );
 }
+
+interface StatCardProps {
+  number: number;
+  label: string;
+}
+
+const StatCard = ({ number, label }: StatCardProps) => {
+  return (
+    <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
+      <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
+        <Text align="center">
+          {number}
+        </Text>
+        <Text color="dimmed" align="center" size="xs">
+          {label}
+        </Text>
+      </Stack>
+    </Card>
+  );
+};
 
 export default definition;


### PR DESCRIPTION
### Category
> Cosmetic

### Overview
> Media request Stats widget: 
> Made the 3 elements stretch to fit the whole widget.
> Added option to display horizontally or vertically.

### Issue Number
> Related issue: #888 

### Screenshot
Those are the smallest possible size.

> Horizontal
> ![image](https://github.com/ajnart/homarr/assets/26098587/6db56704-f4f3-4afb-8e8a-332517a45129)

> Vertical
> ![image](https://github.com/ajnart/homarr/assets/26098587/8165de87-74a9-45e2-9e35-5a8d0958d708)

> Options
> ![image](https://github.com/ajnart/homarr/assets/26098587/0acab6b5-94bf-4cfb-8dcd-9576336af557)
