### PR TITLE
Adding 'audio' session type for Plex based on 'track' Plex API

### DIFF
--- a/src/tools/server/sdk/plex/plexClient.ts
+++ b/src/tools/server/sdk/plex/plexClient.ts
@@ -104,6 +104,8 @@ export class PlexClient {
         return 'movie';
       case 'episode':
         return 'video';
+      case 'track':
+        return 'audio';
       default:
         return undefined;
     }


### PR DESCRIPTION
### Category
Feature

### Overview
During playback, via Plex Session API, within the `MediaContainer` node, music playback appears to be described in `Track` node, whereas Videos appears to be in `Video` node. Within the `Track` node, attribute `type` appears to be set to `track` for various music files I have; as such, I believe using this can be a reasonable detection for audio playback.

Here is a sample response from when playing a file in my music library with actual ID3 and user info redacted:

```
<?xml version="1.0" encoding="UTF-8"?>
<MediaContainer size="1">
<Track addedAt="1678845375" duration="306106" grandparentGuid="plex://artist/5d07bc3440000000000d2780" grandparentKey="/library/metadata/26650" grandparentRatingKey="26650" grandparentThumb="/library/metadata/26650/thumb/1690972605" grandparentTitle="ARTIST NAME" guid="plex://track/5d07d7ce0000000090b65b35" index="1" key="/library/metadata/26657" lastViewedAt="1688042490" librarySectionID="9" librarySectionKey="/library/sections/9" librarySectionTitle="Music" musicAnalysisVersion="1" parentGuid="plex://album/5d07c3bc0000640290997a45" parentIndex="1" parentKey="/library/metadata/26656" parentRatingKey="26656" parentStudio="STUDIO NAME" parentThumb="/library/metadata/26656/thumb/1681465512" parentTitle="ALBUM TITLE" parentYear="2008" ratingCount="1679" ratingKey="26657" sessionKey="145" thumb="/library/metadata/26656/thumb/1681465512" title="SONG TITLE" type="track" updatedAt="1684064252" viewCount="3" viewOffset="16484">
<Media audioChannels="2" audioCodec="mp3" bitrate="320" container="mp3" duration="306106" id="79423">
<Part container="mp3" duration="306106" file="/export/media/Music/ARTIST/ALBUM/01 song.mp3" hasThumbnail="1" id="79663" key="/library/parts/79663/1521986176/file.mp3" size="12574363">
<Stream albumGain="-8.57" albumPeak="1.000000" albumRange="6.435330" audioChannelLayout="stereo" bitrate="320" channels="2" codec="mp3" displayTitle="MP3 (Stereo)" extendedDisplayTitle="MP3 (Stereo)" gain="-8.57" id="193754" index="0" loudness="-9.43" lra="5.51" peak="1.000000" samplingRate="44100" selected="1" streamType="2" />
</Part>
</Media>
<User id="1" thumb="https://plex.tv/users/9c7d14100004067d/avatar?c=100008121" title="username" />
<Player address="10.0.128.2" device="macOS" machineIdentifier="d2f5faa2-0000-0000-0000-000000000bf0" platform="macOS" platformVersion="22.5.0" product="Plexamp" remotePublicAddress="127.0.0.1" state="playing" title="User Friendly Machine Name" version="4.8.1" local="1" relayed="0" secure="1" userID="1" />
</Track>
</MediaContainer>
```

As an aside, while digging through this, I've noticed that in the same file, currently there is a note that suggesting Plex does not have JSON API. This is incorrect. The response of the same endpoint used ( `${this.apiAddress}/status/sessions?X-Plex-Token=${this.token}` ) will return JSON response if `'Accept: application/json, text/plain, */*'` HTTP header is provided, however, I believe it is possible to use something as described [here on stackoverflow](https://stackoverflow.com/a/55238033) to inject the `Accept` header with the appropriate values. As I am not a TS developer by trade, and would really rather not make a big mess of things refactoring this to use JSON instead of XML, I'll probably just raise a separate issue and leave it to the pros.