### PR TITLE
🐛 Mobile category calendar day text wrapping

### DIFF
--- a/src/widgets/calendar/CalendarDay.tsx
+++ b/src/widgets/calendar/CalendarDay.tsx
@@ -104,7 +104,7 @@ export const CalendarDay = ({ date, medias, size }: CalendarDayProps) => {
                   position="bottom-end"
                   medias={medias.musics}
                 >
-                  <div style={{ textAlign: 'center' }}>{date.getDate()}</div>
+                  <div style={{ textAlign: 'center', whiteSpace: 'nowrap' }}>{date.getDate()}</div>
                 </DayIndicator>
               </DayIndicator>
             </DayIndicator>


### PR DESCRIPTION
### Category
> One of: Bugfix

### Overview
> Text in the calendar day used to wrap when the Calendar was seen on mobile in a category. (That is a very, very specific condition)

### Issue Number _(if applicable)_
> Closes issue: #970

### Screenshots
![](https://github.com/ajnart/homarr/assets/26098587/d27ae7cf-f871-4c9f-b4fd-550ce945f38a)
