### PR TITLE
⏪ Revert line clamp

### DIFF
--- a/src/components/Dashboard/Tiles/Apps/AppTile.tsx
+++ b/src/components/Dashboard/Tiles/Apps/AppTile.tsx
@@ -59,7 +59,7 @@ export const AppTile = ({ className, app }: AppTileProps) => {
               ta="center"
               weight={700}
               className={cx(classes.appName, 'dashboard-tile-app-title')}
-              lineClamp={2}
+              lineClamp={1}
             >
               {app.name}
             </Text>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 262da09</samp>

### Summary
📉🚫🧑‍🎨

<!--
1.  📉 This emoji can be used to indicate that the `lineClamp` property was decreased or reduced.
2.  🚫 This emoji can be used to indicate that the app name was prevented from overflowing the tile or exceeding the available space.
3.  🧑‍🎨 This emoji can be used to indicate that the visual consistency or design of the dashboard was improved or enhanced.
-->
Reduced the number of lines for app names on the dashboard tiles to avoid overflow and improve appearance. Modified the `lineClamp` property in `AppTile.tsx`.

> _`lineClamp` is one_
> _App name fits in the tile_
> _Winter of order_

### Walkthrough
* Reduce the `lineClamp` property of the app name `Text` component to 1 to prevent overflow and improve consistency ([link](https://github.com/ajnart/homarr/pull/1245/files?diff=unified&w=0#diff-5632f50450a61a685717bc9da3a49edeb123261246f0400194b526d7d7ada2b5L62-R62))

