### PR TITLE
fix: currentConfig not loaded in useEffect callback

### DIFF
--- a/src/config/provider.tsx
+++ b/src/config/provider.tsx
@@ -41,7 +41,7 @@ export const ConfigProvider = ({
     setPrimaryColor(currentConfig?.settings.customization.colors.primary || 'red');
     setSecondaryColor(currentConfig?.settings.customization.colors.secondary || 'orange');
     setPrimaryShade(currentConfig?.settings.customization.colors.shade || 6);
-  }, [configName]);
+  }, [currentConfig]);
 
   return (
     <ConfigContext.Provider


### PR DESCRIPTION
### Category
Bugfix

### Overview
The following has an enclosure problem. https://github.com/ajnart/homarr/blob/e755bf6bd0ef97fa225200bfe9073f5fae5b1769/src/config/provider.tsx#L38-L44 

`currentConfig` enclosed in the `useEffect` will be undefined upon the call because it is undefined when the callback is created. We should add `currentConfig` to dependency instead of using `configName`. 

### Issue Number _(if applicable)_
This fixes #1249