### PR TITLE
💄 Fix white space on torrent

### DIFF
--- a/src/widgets/torrent/TorrentQueueItem.tsx
+++ b/src/widgets/torrent/TorrentQueueItem.tsx
@@ -10,6 +10,7 @@ import {
   Progress,
   Stack,
   Text,
+  createStyles,
   useMantineTheme,
 } from '@mantine/core';
 import { useDisclosure, useElementSize } from '@mantine/hooks';
@@ -38,6 +39,7 @@ export const BitTorrrentQueueItem = ({ torrent, app }: TorrentQueueItemProps) =>
   const [popoverOpened, { open: openPopover, close: closePopover }] = useDisclosure(false);
   const theme = useMantineTheme();
   const { width } = useElementSize();
+  const { classes } = useStyles();
   const { t } = useTranslation('modules/torrents-status');
 
   const downloadSpeed = torrent.downloadSpeed / 1024 / 1024;
@@ -74,25 +76,33 @@ export const BitTorrrentQueueItem = ({ torrent, app }: TorrentQueueItemProps) =>
         </Popover>
       </td>
       <td>
-        <Text size="xs">{humanFileSize(size, false)}</Text>
+        <Text className={classes.noTextBreak} size="xs">
+          {humanFileSize(size, false)}
+        </Text>
       </td>
       {theme.fn.largerThan('xs') && (
         <td>
-          <Text size="xs">{downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} Mb/s` : '-'}</Text>
+          <Text className={classes.noTextBreak} size="xs">
+            {downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} Mb/s` : '-'}
+          </Text>
         </td>
       )}
       {theme.fn.largerThan('xs') && (
         <td>
-          <Text size="xs">{uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} Mb/s` : '-'}</Text>
+          <Text className={classes.noTextBreak} size="xs">
+            {uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} Mb/s` : '-'}
+          </Text>
         </td>
       )}
       {theme.fn.largerThan('xs') && (
         <td>
-          <Text size="xs">{torrent.eta <= 0 ? '∞' : calculateETA(torrent.eta)}</Text>
+          <Text className={classes.noTextBreak} size="xs">
+            {torrent.eta <= 0 ? '∞' : calculateETA(torrent.eta)}
+          </Text>
         </td>
       )}
       <td>
-        <Text>{(torrent.progress * 100).toFixed(1)}%</Text>
+        <Text className={classes.noTextBreak}>{(torrent.progress * 100).toFixed(1)}%</Text>
         <Progress
           radius="lg"
           color={torrent.progress === 1 ? 'green' : torrent.state === 'paused' ? 'yellow' : 'blue'}
@@ -219,3 +229,9 @@ const TorrentQueuePopover = ({ torrent, app }: TorrentQueueItemProps) => {
     </Stack>
   );
 };
+
+const useStyles = createStyles(() => ({
+  noTextBreak: {
+    whiteSpace: 'nowrap',
+  },
+}));

--- a/src/widgets/torrent/TorrentQueueItem.tsx
+++ b/src/widgets/torrent/TorrentQueueItem.tsx
@@ -25,6 +25,7 @@ import {
   IconUpload,
 } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
+import { MIN_WIDTH_MOBILE } from '~/constants/constants';
 
 import { calculateETA } from '../../tools/client/calculateEta';
 import { humanFileSize } from '../../tools/humanFileSize';
@@ -33,12 +34,12 @@ import { AppType } from '../../types/app';
 interface TorrentQueueItemProps {
   torrent: NormalizedTorrent;
   app?: AppType;
+  width: number;
 }
 
-export const BitTorrrentQueueItem = ({ torrent, app }: TorrentQueueItemProps) => {
+export const BitTorrrentQueueItem = ({ torrent, width, app }: TorrentQueueItemProps) => {
   const [popoverOpened, { open: openPopover, close: closePopover }] = useDisclosure(false);
   const theme = useMantineTheme();
-  const { width } = useElementSize();
   const { classes } = useStyles();
   const { t } = useTranslation('modules/torrents-status');
 
@@ -80,21 +81,21 @@ export const BitTorrrentQueueItem = ({ torrent, app }: TorrentQueueItemProps) =>
           {humanFileSize(size, false)}
         </Text>
       </td>
-      {theme.fn.largerThan('xs') && (
+      {width > MIN_WIDTH_MOBILE && (
         <td>
           <Text className={classes.noTextBreak} size="xs">
             {downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} Mb/s` : '-'}
           </Text>
         </td>
       )}
-      {theme.fn.largerThan('xs') && (
+      {width > MIN_WIDTH_MOBILE && (
         <td>
           <Text className={classes.noTextBreak} size="xs">
             {uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} Mb/s` : '-'}
           </Text>
         </td>
       )}
-      {theme.fn.largerThan('xs') && (
+      {width > MIN_WIDTH_MOBILE && (
         <td>
           <Text className={classes.noTextBreak} size="xs">
             {torrent.eta <= 0 ? '∞' : calculateETA(torrent.eta)}
@@ -114,7 +115,7 @@ export const BitTorrrentQueueItem = ({ torrent, app }: TorrentQueueItemProps) =>
   );
 };
 
-const TorrentQueuePopover = ({ torrent, app }: TorrentQueueItemProps) => {
+const TorrentQueuePopover = ({ torrent, app }: Omit<TorrentQueueItemProps, 'width'>) => {
   const { t } = useTranslation('modules/torrents-status');
   const { colors } = useMantineTheme();
 

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -1,4 +1,4 @@
-import { NormalizedTorrent } from '@ctrl/shared-torrent';
+import { NormalizedTorrent, TorrentState } from '@ctrl/shared-torrent';
 import {
   Badge,
   Center,
@@ -19,9 +19,9 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { useTranslation } from 'next-i18next';
 
 import { MIN_WIDTH_MOBILE } from '../../constants/constants';
-import { useGetDownloadClientsQueue } from '../download-speed/useGetNetworkSpeed';
 import { NormalizedDownloadQueueResponse } from '../../types/api/downloads/queue/NormalizedDownloadQueueResponse';
 import { AppIntegrationType } from '../../types/app';
+import { useGetDownloadClientsQueue } from '../download-speed/useGetNetworkSpeed';
 import { defineWidget } from '../helper';
 import { IWidget } from '../widgets';
 import { BitTorrrentQueueItem } from './TorrentQueueItem';
@@ -112,7 +112,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
     );
   }
 
-  if (data.apps.length === 0) {
+  /*if (data.apps.length === 0) {
     return (
       <Stack>
         <Title order={3}>{t('card.errors.noDownloadClients.title')}</Title>
@@ -130,9 +130,37 @@ function TorrentTile({ widget }: TorrentTileProps) {
       </Center>
     );
   }
-
+*/
   const torrents = data.apps.flatMap((app) => (app.type === 'torrent' ? app.torrents : []));
-  const filteredTorrents = filterTorrents(widget, torrents);
+  //const filteredTorrents = filterTorrents(widget, torrents);
+
+  const filteredTorrents = [
+    {
+      id: '1',
+      name: 'test',
+      connectedPeers: 1,
+      downloadSpeed: 1,
+      connectedSeeds: 1,
+      dateAdded: '2021-09-01T00:00:00.000Z',
+      eta: 1,
+      isCompleted: false,
+      label: 'test',
+      progress: 1,
+      queuePosition: 1,
+      ratio: 1,
+      raw: {},
+      savePath: 'test',
+      state: TorrentState.downloading,
+      totalPeers: 1,
+      totalSeeds: 1,
+      totalSize: 1,
+      uploadSpeed: 1,
+      stateMessage: 'test',
+      totalUploaded: 1,
+      totalDownloaded: 1,
+      totalSelected: 1,
+    },
+  ] satisfies NormalizedTorrent[];
 
   const difference = new Date().getTime() - dataUpdatedAt;
   const duration = dayjs.duration(difference, 'ms');
@@ -154,7 +182,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
           </thead>
           <tbody>
             {filteredTorrents.map((torrent, index) => (
-              <BitTorrrentQueueItem key={index} torrent={torrent} app={undefined} />
+              <BitTorrrentQueueItem key={index} torrent={torrent} width={width} app={undefined} />
             ))}
 
             {filteredTorrents.length !== torrents.length && (

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -112,7 +112,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
     );
   }
 
-  /*if (data.apps.length === 0) {
+  if (data.apps.length === 0) {
     return (
       <Stack>
         <Title order={3}>{t('card.errors.noDownloadClients.title')}</Title>
@@ -130,37 +130,9 @@ function TorrentTile({ widget }: TorrentTileProps) {
       </Center>
     );
   }
-*/
-  const torrents = data.apps.flatMap((app) => (app.type === 'torrent' ? app.torrents : []));
-  //const filteredTorrents = filterTorrents(widget, torrents);
 
-  const filteredTorrents = [
-    {
-      id: '1',
-      name: 'test',
-      connectedPeers: 1,
-      downloadSpeed: 1,
-      connectedSeeds: 1,
-      dateAdded: '2021-09-01T00:00:00.000Z',
-      eta: 1,
-      isCompleted: false,
-      label: 'test',
-      progress: 1,
-      queuePosition: 1,
-      ratio: 1,
-      raw: {},
-      savePath: 'test',
-      state: TorrentState.downloading,
-      totalPeers: 1,
-      totalSeeds: 1,
-      totalSize: 1,
-      uploadSpeed: 1,
-      stateMessage: 'test',
-      totalUploaded: 1,
-      totalDownloaded: 1,
-      totalSelected: 1,
-    },
-  ] satisfies NormalizedTorrent[];
+  const torrents = data.apps.flatMap((app) => (app.type === 'torrent' ? app.torrents : []));
+  const filteredTorrents = filterTorrents(widget, torrents);
 
   const difference = new Date().getTime() - dataUpdatedAt;
   const duration = dayjs.duration(difference, 'ms');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9aad8db</samp>

### Summary
🎨🛠️🧑‍💻

<!--
1.  🎨 - This emoji is often used for changes related to improving the UI or the appearance of the code. It could be used to indicate that the pull request adds custom styles to the component.
2.  🛠️ - This emoji is often used for changes related to fixing or refactoring the code. It could be used to indicate that the pull request improves the layout of the torrent table by applying a class to prevent text breaking.
3.  🧑‍💻 - This emoji is often used for changes related to the developer experience or the code quality. It could be used to indicate that the pull request uses the Material UI functions and hooks to create and apply the styles.
-->
Added custom styles to `BitTorrentQueueItem` component to prevent text overflow in torrent table. Used Material UI functions and hooks to apply styles in `src/widgets/torrent/TorrentQueueItem.tsx`.

> _We're sailing on the torrent sea, with bits and bytes aplenty_
> _We need to keep our table neat, with `BitTorrentQueueItem`_
> _We use the `createStyles` function, and the `useStyles` hook_
> _We apply the `noTextBreak` class, and now our text fields look good_

### Walkthrough
* Import `createStyles` function from `@material-ui/core/styles` to define custom styles for `BitTorrentQueueItem` component ([link](https://github.com/ajnart/homarr/pull/1254/files?diff=unified&w=0#diff-0b76003873f2942f4a0388036004f15fcfba07911622ace8dac6ddc32694e98cR13))
* Invoke `useStyles` hook to access custom classes in `BitTorrentQueueItem` component ([link](https://github.com/ajnart/homarr/pull/1254/files?diff=unified&w=0#diff-0b76003873f2942f4a0388036004f15fcfba07911622ace8dac6ddc32694e98cR42))
* Apply `noTextBreak` class to `Text` components that display torrent size, speed, eta and progress to prevent text wrapping and keep table columns aligned ([link](https://github.com/ajnart/homarr/pull/1254/files?diff=unified&w=0#diff-0b76003873f2942f4a0388036004f15fcfba07911622ace8dac6ddc32694e98cL77-R105))
* Define `useStyles` hook using `createStyles` function and create `noTextBreak` class with `whiteSpace: 'nowrap'` property ([link](https://github.com/ajnart/homarr/pull/1254/files?diff=unified&w=0#diff-0b76003873f2942f4a0388036004f15fcfba07911622ace8dac6ddc32694e98cR232-R237))

