### PR TITLE
🐛 Added movie in icon list for currently playing

### DIFF
--- a/src/widgets/media-server/NowPlayingDisplay.tsx
+++ b/src/widgets/media-server/NowPlayingDisplay.tsx
@@ -3,6 +3,7 @@ import {
   Icon,
   IconDeviceTv,
   IconHeadphones,
+  IconMovie,
   IconQuestionMark,
   IconVideo,
 } from '@tabler/icons-react';
@@ -23,6 +24,8 @@ export const NowPlayingDisplay = ({ session }: { session: GenericSessionInfo }) 
         return IconHeadphones;
       case 'tv':
         return IconDeviceTv;
+      case 'movie':
+        return IconMovie;
       case 'video':
         return IconVideo;
       default:


### PR DESCRIPTION
### Category
> One of: Bugfix 

### Overview
> Movies were forgotten in the "Currently playing" list and showed a default "?" icon.

### Issue Number _(if applicable)_
> Closes #1302

### Screenshot 
> ![image](https://github.com/ajnart/homarr/assets/26098587/93f42236-50f6-422a-8e05-0f8b379cdefb)

