### PR TITLE
🐛 Plex tv-show formatting like jellyfin

### DIFF
--- a/src/tools/server/sdk/plex/plexClient.ts
+++ b/src/tools/server/sdk/plex/plexClient.ts
@@ -35,6 +35,7 @@ export class PlexClient {
         const playerElement = this.findElement('Player', videoElement.elements);
         const mediaElement = this.findElement('Media', videoElement.elements);
         const sessionElement = this.findElement('Session', videoElement.elements);
+        const transcodingElement = this.findElement('TranscodeSession', videoElement.elements);
 
         if (!playerElement || !mediaElement) {
           return undefined;
@@ -43,7 +44,6 @@ export class PlexClient {
         const { videoCodec, videoFrameRate, audioCodec, audioChannels, height, width, bitrate } =
           mediaElement;
 
-        const transcodingElement = this.findElement('TranscodeSession', videoElement.elements);
 
         return {
           id: sessionElement?.id as string | undefined,
@@ -51,7 +51,10 @@ export class PlexClient {
           userProfilePicture: userElement?.thumb as string | undefined,
           sessionName: `${playerElement.product} (${playerElement.title})`,
           currentlyPlaying: {
-            name: videoElement.attributes?.title as string,
+            name: `${videoElement.attributes?.grandparentTitle ?? videoElement.attributes?.title}`,
+            seasonName: videoElement.attributes?.parentTitle,
+            episodeName: videoElement.attributes?.title,
+            episodeCount: videoElement.attributes?.index ?? undefined,
             type: this.getCurrentlyPlayingType(videoElement.attributes?.type as string),
             metadata: {
               video: {


### PR DESCRIPTION
### Category
> One of: Bugfix

### Overview
> Plex tv-shows only shows the epsiode's name, not the series name nor the season like in Jellyfin.
> This PR fixes that. Now plex items look exactly like jellyfin items

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/f55634fd-f0c6-4732-b0b8-74ca8503d0d0)
