### PR TITLE
🐛 Page Metadata space char bug

### DIFF
--- a/src/components/Settings/Customization/Meta/FaviconChanger.tsx
+++ b/src/components/Settings/Customization/Meta/FaviconChanger.tsx
@@ -16,8 +16,7 @@ export const FaviconChanger = () => {
   if (!configName) return null;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (ev) => {
-    const { value } = ev.currentTarget;
-    const faviconUrl = value.trim();
+    const { value: faviconUrl } = ev.currentTarget;
     setFaviconUrl(faviconUrl);
     updateConfig(configName, (prev) => ({
       ...prev,

--- a/src/components/Settings/Customization/Meta/LogoImageChanger.tsx
+++ b/src/components/Settings/Customization/Meta/LogoImageChanger.tsx
@@ -9,23 +9,22 @@ export const LogoImageChanger = () => {
   const { t } = useTranslation('settings/customization/page-appearance');
   const updateConfig = useConfigStore((x) => x.updateConfig);
   const { config, name: configName } = useConfigContext();
-  const [logoImageSrc, setLogoImageSrc] = useState(
+  const [logoImageUrl, setLogoImageUrl] = useState(
     config?.settings.customization.logoImageUrl ?? '/imgs/logo/logo.png'
   );
 
   if (!configName) return null;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (ev) => {
-    const { value } = ev.currentTarget;
-    const logoImageSrc = value.trim();
-    setLogoImageSrc(logoImageSrc);
+    const { value: logoImageUrl } = ev.currentTarget;
+    setLogoImageUrl(logoImageUrl);
     updateConfig(configName, (prev) => ({
       ...prev,
       settings: {
         ...prev.settings,
         customization: {
           ...prev.settings.customization,
-          logoImageUrl: logoImageSrc,
+          logoImageUrl,
         },
       },
     }));
@@ -36,7 +35,7 @@ export const LogoImageChanger = () => {
       label={t('logo.label')}
       description={t('logo.description')}
       placeholder="/imgs/logo/logo.png"
-      value={logoImageSrc}
+      value={logoImageUrl}
       onChange={handleChange}
       mb="sm"
     />

--- a/src/components/Settings/Customization/Meta/MetaTitleChanger.tsx
+++ b/src/components/Settings/Customization/Meta/MetaTitleChanger.tsx
@@ -14,8 +14,7 @@ export const BrowserTabTitle = () => {
   if (!configName) return null;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (ev) => {
-    const { value } = ev.currentTarget;
-    const metaTitle = value.trim();
+    const { value: metaTitle } = ev.currentTarget;
     setMetaTitle(metaTitle);
     updateConfig(configName, (prev) => ({
       ...prev,

--- a/src/components/Settings/Customization/Meta/PageTitleChanger.tsx
+++ b/src/components/Settings/Customization/Meta/PageTitleChanger.tsx
@@ -14,8 +14,7 @@ export const DashboardTitleChanger = () => {
   if (!configName) return null;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (ev) => {
-    const { value } = ev.currentTarget;
-    const pageTitle = value.trim();
+    const { value: pageTitle } = ev.currentTarget;
     setPageTitle(pageTitle);
     updateConfig(configName, (prev) => ({
       ...prev,


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Trimming caused the user to be unable to write a space character at the end when typing since it was automatically removed.

### Issue Number 
> Closes #1334 
