### PR TITLE
💄 PiHole Summary Percentage Blocked Text

### DIFF
--- a/src/widgets/dnshole/DnsHoleSummary.tsx
+++ b/src/widgets/dnshole/DnsHoleSummary.tsx
@@ -75,6 +75,7 @@ const stats = [
   {
     icon: IconPercentage,
     value: (x) => formatPercentage(x.adsBlockedTodayPercentage, 2),
+    label: 'card.metrics.queriesBlockedTodayPercentage',
     color: 'rgba(255, 165, 20, 0.4)',
   },
   {


### PR DESCRIPTION
### Category
> Cosmetic

### Overview
> Adds the text under the percentage blocked on the pihole summary.
> The text already existed in the translation meaning this was a conscious removal at some point.
> I personally think it looks better/more consistent with the text there.

### Issue Number
> Closes #1280

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/34ed6339-a7d4-4bda-8195-35c0f8b8c5ed)

