### PR TITLE
✨ Rework Media Request Stats Widget

### DIFF
--- a/public/locales/en/modules/media-requests-list.json
+++ b/public/locales/en/modules/media-requests-list.json
@@ -6,6 +6,9 @@
       "title": "Media requests list",
       "replaceLinksWithExternalHost": {
         "label": "Replace links with external host"
+      },
+      "openInNewTab": {
+        "label": "Open links in new tab"
       }
     }
   },

--- a/public/locales/en/modules/media-requests-stats.json
+++ b/public/locales/en/modules/media-requests-stats.json
@@ -6,6 +6,9 @@
       "title": "Media requests stats",
       "replaceLinksWithExternalHost": {
         "label": "Replace links with external host"
+      },
+      "openInNewTab": {
+        "label": "Open links in new tab"
       }
     }
   },

--- a/public/locales/en/modules/media-requests-stats.json
+++ b/public/locales/en/modules/media-requests-stats.json
@@ -13,9 +13,15 @@
       }
     }
   },
-  "stats": {
+  "mediaStats": {
+    "title": "Media Stats",
     "pending": "Pending approvals",
     "tvRequests": "TV requests",
-    "movieRequests": "Movie requests"
+    "movieRequests": "Movie requests",
+    "totalRequests": "Total"
+  },
+  "userStats": {
+    "title": "Users",
+    "requests": "Requests: {{number}}"
   }
 }

--- a/public/locales/en/modules/media-requests-stats.json
+++ b/public/locales/en/modules/media-requests-stats.json
@@ -18,10 +18,11 @@
     "pending": "Pending approvals",
     "tvRequests": "TV requests",
     "movieRequests": "Movie requests",
+    "approved": "Already approved",
     "totalRequests": "Total"
   },
   "userStats": {
-    "title": "Users",
+    "title": "Top Users",
     "requests": "Requests: {{number}}"
   }
 }

--- a/public/locales/en/modules/media-requests-stats.json
+++ b/public/locales/en/modules/media-requests-stats.json
@@ -4,12 +4,8 @@
     "description": "Statistics about your media requests",
     "settings": {
       "title": "Media requests stats",
-      "direction": {
-        "label": "Direction of the layout.",
-        "data":{
-          "row": "Horizontal",
-          "column": "Vertical"
-        }
+      "replaceLinksWithExternalHost": {
+        "label": "Replace links with external host"
       }
     }
   },

--- a/src/server/api/routers/media-request.ts
+++ b/src/server/api/routers/media-request.ts
@@ -21,8 +21,6 @@ export const mediaRequestsRouter = createTRPCRouter({
         checkIntegrationsType(app.integration, ['overseerr', 'jellyseerr'])
       );
 
-      Consola.log(`Retrieving media requests from ${apps.length} apps`);
-
       const promises = apps.map((app): Promise<MediaRequest[]> => {
         const apiKey =
           app.integration?.properties.find((prop) => prop.field === 'apiKey')?.value ?? '';
@@ -54,7 +52,7 @@ export const mediaRequestsRouter = createTRPCRouter({
                   rootFolder: item.rootFolder,
                   type: item.type,
                   name: genericItem.name,
-                  userName: item.requestedBy.username,
+                  userName: item.requestedBy.displayName,
                   userProfilePicture: constructAvatarUrl(appUrl, item.requestedBy.avatar),
                   userLink: `${appUrl}/users/${item.requestedBy.id}`,
                   userRequestCount: item.requestedBy.requestCount,
@@ -95,8 +93,6 @@ export const mediaRequestsRouter = createTRPCRouter({
         checkIntegrationsType(app.integration, ['overseerr', 'jellyseerr'])
       );
 
-      Consola.log(`Retrieving media requests from ${apps.length} apps`);
-
       const promises = apps.map((app): Promise<Users[]> => {
         const apiKey =
           app.integration?.properties.find((prop) => prop.field === 'apiKey')?.value ?? '';
@@ -118,7 +114,7 @@ export const mediaRequestsRouter = createTRPCRouter({
                 return {
                   app: app.integration?.type ?? 'overseerr',
                   id: user.id,
-                  userName: user.username,
+                  userName: user.displayName,
                   userProfilePicture: constructAvatarUrl(appUrl, user.avatar),
                   userLink: `${appUrl}/users/${user.id}`,
                   userRequestCount: user.requestCount,
@@ -128,7 +124,7 @@ export const mediaRequestsRouter = createTRPCRouter({
             return Promise.resolve(users);
           })
           .catch((err) => {
-            Consola.error(`Failed to request data from Overseerr: ${err}`);
+            Consola.error(`Failed to request users from Overseerr: ${err}`);
             return Promise.resolve([]);
           });
       });
@@ -167,7 +163,7 @@ const retrieveDetailsForItem = async (
       backdropPath: series.backdropPath,
       posterPath: series.backdropPath,
     };
-  }
+  };
 
   const movieResponse = await fetch(`${baseUrl}/api/v1/movie/${id}`, {
     headers,
@@ -228,7 +224,7 @@ type OverseerrResponseItemMedia = {
 
 type OverseerrResponseItemUser = {
   id: number;
-  username: string;
+  displayName: string;
   avatar: string;
   requestCount: number;
 };

--- a/src/server/api/routers/media-request.ts
+++ b/src/server/api/routers/media-request.ts
@@ -35,11 +35,7 @@ export const mediaRequestsRouter = createTRPCRouter({
             const mediaWidget = config.widgets.find((x) => x.type === 'media-requests-list') as
               | MediaRequestListWidget
               | undefined;
-            if (!mediaWidget) {
-              Consola.log('No media-requests-list found');
-              return Promise.resolve([]);
-            }
-            const appUrl = mediaWidget.properties.replaceLinksWithExternalHost
+            const appUrl = mediaWidget?.properties.replaceLinksWithExternalHost
               ? app.behaviour.externalUrl
               : app.url;
 
@@ -113,18 +109,14 @@ export const mediaRequestsRouter = createTRPCRouter({
             const mediaWidget = config.widgets.find((x) => x.type === 'media-requests-list') as
               | MediaRequestListWidget
               | undefined;
-            if (!mediaWidget) {
-              Consola.log('No media-requests-list found');
-              return Promise.resolve([]);
-            }
-            const appUrl = mediaWidget.properties.replaceLinksWithExternalHost
+            const appUrl = mediaWidget?.properties.replaceLinksWithExternalHost
               ? app.behaviour.externalUrl
               : app.url;
 
             const users = await Promise.all(
               body.results.map(async (item): Promise<Users> => {
                 return {
-                  appId: app.id,
+                  app: app.integration?.type?? 'overseerr',
                   id: item.id,
                   userName: item.username,
                   userProfilePicture: constructAvatarUrl(appUrl, item.avatar),

--- a/src/server/api/routers/media-request.ts
+++ b/src/server/api/routers/media-request.ts
@@ -6,12 +6,14 @@ import { MediaRequestListWidget } from '~/widgets/media-requests/MediaRequestLis
 import { MediaRequest, Users } from '~/widgets/media-requests/media-request-types';
 
 import { createTRPCRouter, publicProcedure } from '../trpc';
+import { MediaRequestStatsWidget } from '~/widgets/media-requests/MediaRequestStatsTile';
 
 export const mediaRequestsRouter = createTRPCRouter({
   allMedia: publicProcedure
     .input(
       z.object({
         configName: z.string(),
+        widget: z.custom<MediaRequestListWidget>().or(z.custom<MediaRequestStatsWidget>()),
       })
     )
     .query(async ({ input }) => {
@@ -30,10 +32,7 @@ export const mediaRequestsRouter = createTRPCRouter({
         })
           .then(async (response) => {
             const body = (await response.json()) as OverseerrResponse;
-            const mediaWidget = config.widgets.find((x) => x.type === 'media-requests-list') as
-              | MediaRequestListWidget
-              | undefined;
-            const appUrl = mediaWidget?.properties.replaceLinksWithExternalHost
+            const appUrl = input.widget.properties.replaceLinksWithExternalHost
               ? app.behaviour.externalUrl
               : app.url;
 
@@ -84,6 +83,7 @@ export const mediaRequestsRouter = createTRPCRouter({
     .input(
       z.object({
         configName: z.string(),
+        widget: z.custom<MediaRequestListWidget>().or(z.custom<MediaRequestStatsWidget>()),
       })
     )
     .query(async ({ input }) => {
@@ -102,10 +102,7 @@ export const mediaRequestsRouter = createTRPCRouter({
         })
           .then(async (response) => {
             const body = (await response.json()) as OverseerrUsers;
-            const mediaWidget = config.widgets.find((x) => x.type === 'media-requests-list') as
-              | MediaRequestListWidget
-              | undefined;
-            const appUrl = mediaWidget?.properties.replaceLinksWithExternalHost
+            const appUrl = input.widget.properties.replaceLinksWithExternalHost
               ? app.behaviour.externalUrl
               : app.url;
 

--- a/src/server/api/routers/media-request.ts
+++ b/src/server/api/routers/media-request.ts
@@ -114,14 +114,14 @@ export const mediaRequestsRouter = createTRPCRouter({
               : app.url;
 
             const users = await Promise.all(
-              body.results.map(async (item): Promise<Users> => {
+              body.results.map(async (user): Promise<Users> => {
                 return {
-                  app: app.integration?.type?? 'overseerr',
-                  id: item.id,
-                  userName: item.username,
-                  userProfilePicture: constructAvatarUrl(appUrl, item.avatar),
-                  userLink: `${appUrl}/users/${item.id}`,
-                  userRequestCount: item.requestCount,
+                  app: app.integration?.type ?? 'overseerr',
+                  id: user.id,
+                  userName: user.username,
+                  userProfilePicture: constructAvatarUrl(appUrl, user.avatar),
+                  userLink: `${appUrl}/users/${user.id}`,
+                  userRequestCount: user.requestCount,
                 };
               })
             );
@@ -131,19 +131,15 @@ export const mediaRequestsRouter = createTRPCRouter({
             Consola.error(`Failed to request data from Overseerr: ${err}`);
             return Promise.resolve([]);
           });
-      })
-      const users = (await Promise.all(promises)).reduce(
-        (prev, cur) => prev.concat(cur),
-        []
-      );
+      });
+      const users = (await Promise.all(promises)).reduce((prev, cur) => prev.concat(cur), []);
 
       return users;
     }),
 });
 
 const constructAvatarUrl = (appUrl: string, avatar: string) => {
-  const isAbsolute =
-    avatar.startsWith('http://') || avatar.startsWith('https://');
+  const isAbsolute = avatar.startsWith('http://') || avatar.startsWith('https://');
 
   if (isAbsolute) {
     return avatar;
@@ -214,7 +210,7 @@ type OverseerrResponse = {
 
 type OverseerrUsers = {
   results: OverseerrResponseItemUser[];
-}
+};
 
 type OverseerrResponseItem = {
   id: number;

--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   Group,
   Image,
+  ScrollArea,
   Stack,
   Text,
   Tooltip,
@@ -27,6 +28,10 @@ const definition = defineWidget({
   icon: IconGitPullRequest,
   options: {
     replaceLinksWithExternalHost: {
+      type: 'switch',
+      defaultValue: true,
+    },
+    openInNewTab: {
       type: 'switch',
       defaultValue: true,
     },
@@ -126,115 +131,118 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
   });
 
   return (
-    <Stack>
-      {countPendingApproval > 0 ? (
-        <Text>{t('pending', { countPendingApproval })}</Text>
-      ) : (
-        <Text>{t('nonePending')}</Text>
-      )}
-      {sortedData.map((item) => (
-        <Card withBorder>
-          <Flex wrap="wrap" justify="space-between" gap="md">
-            <Flex gap="md">
-              <Image
-                src={item.posterPath}
-                width={30}
-                height={50}
-                alt="poster"
-                radius="xs"
-                withPlaceholder
-              />
-              <Stack spacing={0}>
-                <Group spacing="xs">
-                  {item.airDate && <Text>{item.airDate.split('-')[0]}</Text>}
-                  <MediaRequestStatusBadge status={item.status} />
-                </Group>
-                <Text
-                  sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
-                  lineClamp={1}
-                  weight="bold"
-                  component="a"
-                  href={item.href}
-                >
-                  {item.name}
-                </Text>
-              </Stack>
-            </Flex>
-            <Stack justify="center">
-              <Flex gap="xs">
+    <ScrollArea h="100%">
+      <Stack>
+        {countPendingApproval > 0 ? (
+          <Text>{t('pending', { countPendingApproval })}</Text>
+        ) : (
+          <Text>{t('nonePending')}</Text>
+        )}
+        {sortedData.map((item) => (
+          <Card radius="md" withBorder>
+            <Flex wrap="wrap" justify="space-between" gap="md">
+              <Flex gap="md">
                 <Image
-                  src={item.userProfilePicture}
-                  width={25}
-                  height={25}
-                  alt="requester avatar"
-                  radius="xl"
+                  src={item.posterPath}
+                  width={30}
+                  height={50}
+                  alt="poster"
+                  radius="xs"
                   withPlaceholder
                 />
-                <Text
-                  component="a"
-                  href={item.userLink}
-                  sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
-                >
-                  {item.userName}
-                </Text>
+                <Stack spacing={0}>
+                  <Group spacing="xs">
+                    {item.airDate && <Text>{item.airDate.split('-')[0]}</Text>}
+                    <MediaRequestStatusBadge status={item.status} />
+                  </Group>
+                  <Text
+                    sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                    lineClamp={1}
+                    weight="bold"
+                    component="a"
+                    href={item.href}
+                  >
+                    {item.name}
+                  </Text>
+                </Stack>
               </Flex>
+              <Stack justify="center">
+                <Flex gap="xs">
+                  <Image
+                    src={item.userProfilePicture}
+                    width={25}
+                    height={25}
+                    alt="requester avatar"
+                    radius="xl"
+                    withPlaceholder
+                  />
+                  <Text
+                    component="a"
+                    href={item.userLink}
+                    target={widget.properties.openInNewTab ? "_blank" : "_self"}
+                    sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                  >
+                    {item.userName}
+                  </Text>
+                </Flex>
 
-              {item.status === MediaRequestStatus.PendingApproval && (
-                <Group>
-                  <Tooltip label={t('tooltips.approve')} withArrow withinPortal>
-                    <ActionIcon
-                      variant="light"
-                      color="green"
-                      onClick={async () => {
-                        notifications.show({
-                          id: `approve ${item.id}`,
-                          color: 'yellow',
-                          title: t('tooltips.approving'),
-                          message: undefined,
-                          loading: true,
-                        });
+                {item.status === MediaRequestStatus.PendingApproval && (
+                  <Group>
+                    <Tooltip label={t('tooltips.approve')} withArrow withinPortal>
+                      <ActionIcon
+                        variant="light"
+                        color="green"
+                        onClick={async () => {
+                          notifications.show({
+                            id: `approve ${item.id}`,
+                            color: 'yellow',
+                            title: t('tooltips.approving'),
+                            message: undefined,
+                            loading: true,
+                          });
 
-                        await decideAsync({
-                          request: item,
-                          isApproved: true,
-                        });
-                      }}
-                    >
-                      <IconThumbUp />
-                    </ActionIcon>
-                  </Tooltip>
-                  <Tooltip label={t('tooltips.decline')} withArrow withinPortal>
-                    <ActionIcon
-                      variant="light"
-                      color="red"
-                      onClick={async () => {
-                        await decideAsync({
-                          request: item,
-                          isApproved: false,
-                        });
-                      }}
-                    >
-                      <IconThumbDown />
-                    </ActionIcon>
-                  </Tooltip>
-                </Group>
-              )}
-            </Stack>
-          </Flex>
+                          await decideAsync({
+                            request: item,
+                            isApproved: true,
+                          });
+                        }}
+                      >
+                        <IconThumbUp />
+                      </ActionIcon>
+                    </Tooltip>
+                    <Tooltip label={t('tooltips.decline')} withArrow withinPortal>
+                      <ActionIcon
+                        variant="light"
+                        color="red"
+                        onClick={async () => {
+                          await decideAsync({
+                            request: item,
+                            isApproved: false,
+                          });
+                        }}
+                      >
+                        <IconThumbDown />
+                      </ActionIcon>
+                    </Tooltip>
+                  </Group>
+                )}
+              </Stack>
+            </Flex>
 
-          <Image
-            src={item.backdropPath}
-            pos="absolute"
-            w="100%"
-            h="100%"
-            opacity={0.1}
-            top={0}
-            left={0}
-            style={{ pointerEvents: 'none' }}
-          />
-        </Card>
-      ))}
-    </Stack>
+            <Image
+              src={item.backdropPath}
+              pos="absolute"
+              w="100%"
+              h="100%"
+              opacity={0.1}
+              top={0}
+              left={0}
+              style={{ pointerEvents: 'none' }}
+            />
+          </Card>
+        ))}
+      </Stack>
+    </ScrollArea>
   );
 }
 

--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -94,7 +94,7 @@ const useMediaRequestDecisionMutation = () => {
 
 function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
   const { t } = useTranslation('modules/media-requests-list');
-  const { data, isLoading } = useMediaRequestQuery();
+  const { data, isLoading } = useMediaRequestQuery(widget);
   // Use mutation to approve or deny a pending request
   const decideAsync = useMediaRequestDecisionMutation();
 

--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -55,7 +55,8 @@ const useMediaRequestDecisionMutation = () => {
   const utils = api.useContext();
   const { mutateAsync } = api.overseerr.decide.useMutation({
     onSuccess() {
-      utils.mediaRequest.all.invalidate();
+      utils.mediaRequest.allMedia.invalidate();
+      utils.mediaRequest.users.invalidate();
     },
   });
   const { t } = useTranslation('modules/media-requests-list');

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -1,26 +1,18 @@
-import { Card, Flex, Stack, Text } from '@mantine/core';
+import { Avatar, Card, Flex, Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
 import { IconChartBar } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
 
 import { defineWidget } from '../helper';
 import { WidgetLoading } from '../loading';
 import { IWidget } from '../widgets';
-import { useMediaRequestQuery } from './media-request-query';
+import { useMediaRequestQuery, useUsersQuery } from './media-request-query';
 import { MediaRequestStatus } from './media-request-types';
 
 const definition = defineWidget({
   id: 'media-requests-stats',
   icon: IconChartBar,
-  options: {
-    direction: {
-      type: 'select',
-      defaultValue: 'row' as 'row' | 'column',
-      data: [
-        { value: 'row' },
-        { value: 'column' },
-      ],
-    },
-  },
+  options: {},
   gridstack: {
     minWidth: 1,
     minHeight: 1,
@@ -38,53 +30,90 @@ interface MediaRequestStatsWidgetProps {
 
 function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
   const { t } = useTranslation('modules/media-requests-stats');
-  const { data, isFetching } = useMediaRequestQuery();
+  const { data: mediaData, isFetching: mediaFetching } = useMediaRequestQuery();
+  const { data: usersData, isFetching: usersFetching } = useUsersQuery();
+  const { ref, height } = useElementSize();
 
-  if (!data || isFetching) {
+  if (!mediaData || mediaFetching || !usersData || usersFetching) {
     return <WidgetLoading />;
   }
 
+  const baseStats: { label: string; number: number }[] = [
+    {
+      label: t('mediaStats.pending'),
+      number: mediaData.filter((x) => x.status === MediaRequestStatus.PendingApproval).length,
+    },
+    {
+      label: t('mediaStats.tvRequests'),
+      number: mediaData.filter((x) => x.type === 'tv').length,
+    },
+    {
+      label: t('mediaStats.movieRequests'),
+      number: mediaData.filter((x) => x.type === 'movie').length,
+    },
+    {
+      label: t('mediaStats.totalRequests'),
+      number: mediaData.length,
+    },
+  ];
+
+  const users: { username: string; avatar: string; href: string; requests: number }[] = usersData
+    .sort((x, y) => x.userRequestCount - y.userRequestCount)
+    .slice(0, Math.trunc(height / 50))
+    .map((x) => {
+      return {
+        username: x.userName,
+        avatar: x.userProfilePicture,
+        href: x.userLink,
+        requests: x.userRequestCount,
+      };
+    });
+
   return (
-    <Flex
-      w="100%"
-      h="100%"
-      gap="md"
-      direction={ widget.properties.direction?? 'row' }
-    >
-      <StatCard
-        number={data.filter((x) => x.status === MediaRequestStatus.PendingApproval).length}
-        label={t('stats.pending')}
-      />
-      <StatCard
-        number={data.filter((x) => x.type === 'tv').length}
-        label={t('stats.tvRequests')}
-      />
-      <StatCard
-        number={data.filter((x) => x.type === 'movie').length}
-        label={t('stats.movieRequests')}
-      />
+    <Flex h="100%" gap={0} direction="column">
+      <Text mt={-7}>{t('mediaStats.title')}</Text>
+      <Card withBorder py={5} px={10} style={{ overflow: 'unset' }}>
+        {baseStats.map((stat) => {
+          return (
+            <Group position="apart">
+              <Text color="dimmed" align="center" size="xs">
+                {stat.label}
+              </Text>
+              <Text align="center" size="xs">
+                {stat.number}
+              </Text>
+            </Group>
+          );
+        })}
+      </Card>
+      <Text mt={2} mb={-2}>{t('userStats.title')}</Text>
+      <Stack ref={ref} style={{ flex: 1 }} spacing={0} p={0} sx={{ overflow: 'hidden' }}>
+        {users.map((user) => {
+          return (
+            <Card
+              withBorder
+              p={0}
+              my={3}
+              component="a"
+              href={user.href}
+              target="_blank"
+              mah={75}
+              mih={50}
+              style={{ flex: 1 }}
+            >
+              <Group spacing={0} align="center" h="100%">
+                <Avatar m={5} size={35} src={user.avatar} alt="user avatar"/>
+                <Stack spacing={0}>
+                  <Text>{user.username}</Text>
+                  <Text size="xs">{t('userStats.requests', {number: user.requests})}</Text>
+                </Stack>
+              </Group>
+            </Card>
+          );
+        })}
+      </Stack>
     </Flex>
   );
 }
-
-interface StatCardProps {
-  number: number;
-  label: string;
-}
-
-const StatCard = ({ number, label }: StatCardProps) => {
-  return (
-    <Card w="100%" h="100%" withBorder style={{flex:"1 1 auto"}}>
-      <Stack w="100%" h="100%" align="center" justify="center" spacing={0}>
-        <Text align="center">
-          {number}
-        </Text>
-        <Text color="dimmed" align="center" size="xs">
-          {label}
-        </Text>
-      </Stack>
-    </Card>
-  );
-};
 
 export default definition;

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -26,7 +26,11 @@ const definition = defineWidget({
     replaceLinksWithExternalHost: {
       type: 'switch',
       defaultValue: false,
-    }
+    },
+    openInNewTab: {
+      type: 'switch',
+      defaultValue: true,
+    },
   },
   gridstack: {
     minWidth: 2,
@@ -124,7 +128,7 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
               p={0}
               component="a"
               href={user.userLink}
-              target="_blank"
+              target={widget.properties.openInNewTab ? "_blank" : "_self"}
               mah={95}
               mih={55}
               radius="md"

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -22,7 +22,12 @@ import { MediaRequestStatus } from './media-request-types';
 const definition = defineWidget({
   id: 'media-requests-stats',
   icon: IconChartBar,
-  options: {},
+  options: {
+    replaceLinksWithExternalHost: {
+      type: 'switch',
+      defaultValue: false,
+    }
+  },
   gridstack: {
     minWidth: 2,
     minHeight: 2,
@@ -44,12 +49,12 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
     data: mediaData,
     isFetching: mediaFetching,
     isLoading: mediaLoading,
-  } = useMediaRequestQuery();
+  } = useMediaRequestQuery(widget);
   const {
     data: usersData,
     isFetching: usersFetching,
     isLoading: usersLoading
-  } = useUsersQuery();
+  } = useUsersQuery(widget);
   const { ref, height } = useElementSize();
   const { colorScheme } = useMantineTheme();
 

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -9,10 +9,9 @@ import {
   Tooltip,
   useMantineTheme,
 } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
 import { IconChartBar, IconExternalLink } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
-import { useRef } from 'react';
-import { useResize } from '~/hooks/use-resize';
 
 import { defineWidget } from '../helper';
 import { WidgetLoading } from '../loading';
@@ -41,20 +40,31 @@ interface MediaRequestStatsWidgetProps {
 
 function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
   const { t } = useTranslation('modules/media-requests-stats');
-  const { data: mediaData, isFetching: mediaFetching } = useMediaRequestQuery();
-  const { data: usersData, isFetching: usersFetching } = useUsersQuery();
-  const ref = useRef<HTMLDivElement>(null);
-  const { height } = useResize(ref, []);
+  const {
+    data: mediaData,
+    isFetching: mediaFetching,
+    isLoading: mediaLoading,
+  } = useMediaRequestQuery();
+  const {
+    data: usersData,
+    isFetching: usersFetching,
+    isLoading: usersLoading
+  } = useUsersQuery();
+  const { ref, height } = useElementSize();
   const { colorScheme } = useMantineTheme();
 
-  if (!mediaData || !usersData) {
-    return <WidgetLoading />;
+  if (!mediaData || !usersData || mediaLoading || usersLoading) {
+    return (
+      <Stack ref={ref} h="100%">
+        <WidgetLoading />
+      </Stack>
+    );
   }
 
   const appList: string[] = [];
   mediaData.forEach((item) => {
     if (!appList.includes(item.appId)) appList.push(item.appId);
-  })
+  });
 
   const baseStats: { label: string; number: number }[] = [
     {
@@ -71,7 +81,7 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
     },
     {
       label: t('mediaStats.approved'),
-      number: mediaData.filter((x) => x.status === MediaRequestStatus.Approved).length
+      number: mediaData.filter((x) => x.status === MediaRequestStatus.Approved).length,
     },
     {
       label: t('mediaStats.totalRequests'),
@@ -125,7 +135,7 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
                 display="flex"
                 style={{ flexDirection: 'row' }}
               >
-                {appList.length > 1 &&
+                {appList.length > 1 && (
                   <Tooltip.Floating
                     label={user.app.charAt(0).toUpperCase() + user.app.slice(1)}
                     c={colorScheme === 'light' ? 'black' : 'dark.0'}
@@ -142,7 +152,7 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
                       children
                     />
                   </Tooltip.Floating>
-                }
+                )}
                 <Avatar radius="xl" size={45} src={user.userProfilePicture} alt="user avatar" />
                 <Stack spacing={0} style={{ flex: 1 }}>
                   <Text>{user.userName}</Text>

--- a/src/widgets/media-requests/media-request-query.tsx
+++ b/src/widgets/media-requests/media-request-query.tsx
@@ -3,7 +3,17 @@ import { api } from '~/utils/api';
 
 export const useMediaRequestQuery = () => {
   const { name: configName } = useConfigContext();
-  return api.mediaRequest.all.useQuery(
+  return api.mediaRequest.allMedia.useQuery(
+    { configName: configName! },
+    {
+      refetchInterval: 3 * 60 * 1000,
+    }
+  );
+};
+
+export const useUsersQuery = () => {
+  const { name: configName } = useConfigContext();
+  return api.mediaRequest.users.useQuery(
     { configName: configName! },
     {
       refetchInterval: 3 * 60 * 1000,

--- a/src/widgets/media-requests/media-request-query.tsx
+++ b/src/widgets/media-requests/media-request-query.tsx
@@ -1,20 +1,22 @@
 import { useConfigContext } from '~/config/provider';
+import { MediaRequestListWidget } from './MediaRequestListTile';
+import { MediaRequestStatsWidget } from './MediaRequestStatsTile';
 import { api } from '~/utils/api';
 
-export const useMediaRequestQuery = () => {
+export const useMediaRequestQuery = (widget: MediaRequestListWidget|MediaRequestStatsWidget) => {
   const { name: configName } = useConfigContext();
   return api.mediaRequest.allMedia.useQuery(
-    { configName: configName! },
+    { configName: configName!, widget: widget },
     {
       refetchInterval: 3 * 60 * 1000,
     }
   );
 };
 
-export const useUsersQuery = () => {
+export const useUsersQuery = (widget: MediaRequestListWidget|MediaRequestStatsWidget) => {
   const { name: configName } = useConfigContext();
   return api.mediaRequest.users.useQuery(
-    { configName: configName! },
+    { configName: configName!, widget: widget },
     {
       refetchInterval: 3 * 60 * 1000,
     }

--- a/src/widgets/media-requests/media-request-types.tsx
+++ b/src/widgets/media-requests/media-request-types.tsx
@@ -8,12 +8,22 @@ export type MediaRequest = {
   userName: string;
   userProfilePicture: string;
   userLink: string;
+  userRequestCount: number;
   airDate?: string;
   status: MediaRequestStatus;
   backdropPath: string;
   posterPath: string;
   href: string;
 };
+
+export type Users = {
+  appId: string;
+  id: number;
+  userName: string;
+  userProfilePicture: string;
+  userLink: string;
+  userRequestCount: number;
+}
 
 export enum MediaRequestStatus {
   PendingApproval = 1,

--- a/src/widgets/media-requests/media-request-types.tsx
+++ b/src/widgets/media-requests/media-request-types.tsx
@@ -17,7 +17,7 @@ export type MediaRequest = {
 };
 
 export type Users = {
-  appId: string;
+  app: string;
   id: number;
   userName: string;
   userProfilePicture: string;

--- a/src/widgets/media-requests/media-request-types.tsx
+++ b/src/widgets/media-requests/media-request-types.tsx
@@ -23,7 +23,7 @@ export type Users = {
   userProfilePicture: string;
   userLink: string;
   userRequestCount: number;
-}
+};
 
 export enum MediaRequestStatus {
   PendingApproval = 1,


### PR DESCRIPTION
### Category
> Cosmetic / Feature

### Overview
> Media request widget to show normal media stats (now including total amount of request, decline approved and pending).
> Shows a list of top requester, list length depends on widget total height. The longer the widget get the more users it shows.
> User list cards will grow to always fill all space.
> If there are more than 1 'seerr app, indicators will show which app the user is from.
> Each card directly links to the user profile page on its dedicated 'seerr app (little icon on the left just to clarify to the user).
> 

### Issue Number
> Related issue: #1004 
> Closes : #1297 (I also ended up including it [bbb6b20](https://github.com/ajnart/homarr/pull/1344/commits/bbb6b20b3c0497f1da1803dad5c5733d2acc920d) and saw there was an issue relating to that)

### New Vars
> New router query for *seerr's that requests for users directly.

### Screenshot 
> ![image](https://github.com/ajnart/homarr/assets/26098587/c0450f95-6b92-4439-8fd5-3a800b29840d)
