### PR TITLE
:rewind: Revert anchor colors in media request widget

### DIFF
--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -9,7 +9,7 @@ import {
   ScrollArea,
   Stack,
   Text,
-  Tooltip,
+  Tooltip, useMantineTheme,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconCheck, IconGitPullRequest, IconThumbDown, IconThumbUp } from '@tabler/icons-react';
@@ -103,6 +103,8 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
   // Use mutation to approve or deny a pending request
   const decideAsync = useMediaRequestDecisionMutation();
 
+  const mantineTheme = useMantineTheme();
+
   if (!data || isLoading) {
     return <WidgetLoading />;
   }
@@ -155,7 +157,7 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
                     {item.airDate && <Text>{item.airDate.split('-')[0]}</Text>}
                     <MediaRequestStatusBadge status={item.status} />
                   </Group>
-                  <Anchor href={item.href}>
+                  <Anchor href={item.href} c={mantineTheme.colorScheme === 'dark' ? 'gray.3' : 'gray.8'}>
                     {item.name}
                   </Anchor>
                 </Stack>
@@ -170,14 +172,13 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
                     radius="xl"
                     withPlaceholder
                   />
-                  <Text
-                    component="a"
+                  <Anchor
                     href={item.userLink}
                     target={widget.properties.openInNewTab ? "_blank" : "_self"}
-                    sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                    c={mantineTheme.colorScheme === 'dark' ? 'gray.3' : 'gray.8'}
                   >
                     {item.userName}
-                  </Text>
+                  </Anchor>
                 </Flex>
 
                 {item.status === MediaRequestStatus.PendingApproval && (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9fa0acf</samp>

### Summary
🎨🛠️🧰

<!--
1.  🎨 - This emoji can be used to indicate a change that improves the appearance or design of a component, such as adding colors, icons, animations, or styles.
2.  🛠️ - This emoji can be used to indicate a change that improves the functionality or performance of a component, such as fixing bugs, adding features, or optimizing code.
3.  🧰 - This emoji can be used to indicate a change that involves using or updating a tool or library, such as adding a hook, a component, or a dependency.
-->
Refactored the `MediaRequestListTile` component to use Mantine UI components and theme. This enhances the user interface and code readability.

> _`MediaRequestListTile` is the key to our fate_
> _We use the `useMantineTheme` hook to create_
> _A stunning and functional display_
> _With the `Anchor` component we navigate_

### Walkthrough
* Import and use `useMantineTheme` hook to access the current theme color scheme ([link](https://github.com/ajnart/homarr/pull/1360/files?diff=unified&w=0#diff-d4e1fbb078f6effb9a447121330f078878aa135493bdc92d921f32b37cd66b13L12-R12), [link](https://github.com/ajnart/homarr/pull/1360/files?diff=unified&w=0#diff-d4e1fbb078f6effb9a447121330f078878aa135493bdc92d921f32b37cd66b13R106-R107))
* Conditionally set the color prop of `Anchor` components based on the theme color scheme to improve contrast and readability in dark mode ([link](https://github.com/ajnart/homarr/pull/1360/files?diff=unified&w=0#diff-d4e1fbb078f6effb9a447121330f078878aa135493bdc92d921f32b37cd66b13L158-R160), [link](https://github.com/ajnart/homarr/pull/1360/files?diff=unified&w=0#diff-d4e1fbb078f6effb9a447121330f078878aa135493bdc92d921f32b37cd66b13L173-R181))
* Replace `Text` component with `Anchor` component for consistency and accessibility in `src/widgets/media-requests/MediaRequestListTile.tsx` ([link](https://github.com/ajnart/homarr/pull/1360/files?diff=unified&w=0#diff-d4e1fbb078f6effb9a447121330f078878aa135493bdc92d921f32b37cd66b13L173-R181))

