### PR TITLE
🐛 Media Request List widget add new tab for item

### DIFF
--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -157,7 +157,11 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
                     {item.airDate && <Text>{item.airDate.split('-')[0]}</Text>}
                     <MediaRequestStatusBadge status={item.status} />
                   </Group>
-                  <Anchor href={item.href} c={mantineTheme.colorScheme === 'dark' ? 'gray.3' : 'gray.8'}>
+                  <Anchor
+                    href={item.href}
+                    target={widget.properties.openInNewTab ? "_blank" : "_self"}
+                    c={mantineTheme.colorScheme === 'dark' ? 'gray.3' : 'gray.8'}
+                    >
                     {item.name}
                   </Anchor>
                 </Stack>


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Item was missing the open in new tab field from options.

### Issue Number
> Related issue: reported on discord