### PR TITLE
✨ Hide DNS-Hole control buttons option

### DIFF
--- a/public/locales/en/modules/dns-hole-controls.json
+++ b/public/locales/en/modules/dns-hole-controls.json
@@ -1,6 +1,12 @@
 {
   "descriptor": {
     "name": "DNS hole controls",
-    "description": "Control PiHole or AdGuard from your dashboard"
+    "description": "Control PiHole or AdGuard from your dashboard",
+    "settings": {
+      "title": "DNS hole controls settings",
+      "showToggleAllButtons": {
+        "label": "Show 'Enable/Disable All' Buttons"
+      }
+    }
   }
 }

--- a/src/widgets/dnshole/DnsHoleControls.tsx
+++ b/src/widgets/dnshole/DnsHoleControls.tsx
@@ -24,7 +24,12 @@ import { useDnsHoleSummeryQuery } from './DnsHoleSummary';
 const definition = defineWidget({
   id: 'dns-hole-controls',
   icon: IconDeviceGamepad,
-  options: {},
+  options: {
+    showToggleAllButtons: {
+      type: 'switch',
+      defaultValue: true,
+    },
+  },
   gridstack: {
     minWidth: 2,
     minHeight: 1,
@@ -102,51 +107,66 @@ function DnsHoleControlsWidgetTile({ widget }: DnsHoleControlsWidgetProps) {
   };
 
   return (
-    <Stack justify="space-between" h={'100%'} spacing="0.25rem">
-      <SimpleGrid ref={ref} cols={width > 275 ? 2 : 1} spacing="0.25rem">
-        <Button
-          onClick={async () => {
-            await mutateAsync({
-              action: 'enable',
-              configName,
-              appsToChange: getDnsStatus()?.disabled,
-            },{
-              onSettled: () => {
-                reFetchSummaryDns();
-              }
-            });
-          }}
-          disabled={getDnsStatus()?.disabled.length === 0 || fetchingDnsSummary || changingStatus}
-          leftIcon={<IconPlayerPlay size={20} />}
-          variant="light"
-          color="green"
-          h="2rem"
-        >
-          {t('enableAll')}
-        </Button>
-        <Button
-          onClick={async () => {
-            await mutateAsync({
-              action: 'disable',
-              configName,
-              appsToChange: getDnsStatus()?.enabled,
-            },{
-              onSettled: () => {
-                reFetchSummaryDns();
-              }
-            });
-          }}
-          disabled={getDnsStatus()?.enabled.length === 0 || fetchingDnsSummary || changingStatus}
-          leftIcon={<IconPlayerStop size={20} />}
-          variant="light"
-          color="red"
-          h="2rem"
-        >
-          {t('disableAll')}
-        </Button>
-      </SimpleGrid>
+    <Stack h={'100%'} spacing="0.25rem">
+      {widget.properties.showToggleAllButtons && (
+        <SimpleGrid ref={ref} cols={width > 275 ? 2 : 1} spacing="0.25rem">
+          <Button
+            onClick={async () => {
+              await mutateAsync(
+                {
+                  action: 'enable',
+                  configName,
+                  appsToChange: getDnsStatus()?.disabled,
+                },
+                {
+                  onSettled: () => {
+                    reFetchSummaryDns();
+                  },
+                }
+              );
+            }}
+            disabled={getDnsStatus()?.disabled.length === 0 || fetchingDnsSummary || changingStatus}
+            leftIcon={<IconPlayerPlay size={20} />}
+            variant="light"
+            color="green"
+            h="2rem"
+          >
+            {t('enableAll')}
+          </Button>
+          <Button
+            onClick={async () => {
+              await mutateAsync(
+                {
+                  action: 'disable',
+                  configName,
+                  appsToChange: getDnsStatus()?.enabled,
+                },
+                {
+                  onSettled: () => {
+                    reFetchSummaryDns();
+                  },
+                }
+              );
+            }}
+            disabled={getDnsStatus()?.enabled.length === 0 || fetchingDnsSummary || changingStatus}
+            leftIcon={<IconPlayerStop size={20} />}
+            variant="light"
+            color="red"
+            h="2rem"
+          >
+            {t('disableAll')}
+          </Button>
+        </SimpleGrid>
+      )}
 
-      <Stack spacing="0.25rem">
+      <Stack
+        spacing="0.25rem"
+        display="flex"
+        style={{
+          flex: '1',
+          justifyContent: widget.properties.showToggleAllButtons ? 'flex-end' : 'space-evenly',
+        }}
+      >
         {data.status.map((dnsHole, index) => {
           const app = config?.apps.find((x) => x.id === dnsHole.appId);
 
@@ -155,7 +175,7 @@ function DnsHoleControlsWidgetTile({ widget }: DnsHoleControlsWidgetProps) {
           }
 
           return (
-            <Card withBorder={true} key={dnsHole.appId} p="xs">
+            <Card withBorder={true} key={dnsHole.appId} p="xs" radius="md">
               <Group>
                 <Box
                   sx={(theme) => ({
@@ -172,15 +192,18 @@ function DnsHoleControlsWidgetTile({ widget }: DnsHoleControlsWidgetProps) {
                   <Text>{app.name}</Text>
                   <UnstyledButton
                     onClick={async () => {
-                      await mutateAsync({
-                        action: dnsHole.status === 'enabled' ? 'disable' : 'enable',
-                        configName,
-                        appsToChange: [app.id],
-                      },{
-                        onSettled: () => {
-                          reFetchSummaryDns();
+                      await mutateAsync(
+                        {
+                          action: dnsHole.status === 'enabled' ? 'disable' : 'enable',
+                          configName,
+                          appsToChange: [app.id],
+                        },
+                        {
+                          onSettled: () => {
+                            reFetchSummaryDns();
+                          },
                         }
-                      });
+                      );
                     }}
                     disabled={fetchingDnsSummary || changingStatus}
                   >


### PR DESCRIPTION
### Category
> Feature

### Overview
> As the badge now is usable to toggle instances of dns-holes, some may find the "toggle all" options to be redundant, especially if you only have one dns-hole.
> This helps make the widget itself take even less space on the dashboard.

### Issue Number
> Closes #1382

### Screenshot
> 1 by 2 config 
> ![image](https://github.com/ajnart/homarr/assets/26098587/ef762522-d30a-4345-939c-eb5bce1f601b)

> 2 by 2, single instance is centered
> ![image](https://github.com/ajnart/homarr/assets/26098587/c9c35202-deb2-4a8c-b944-d0a76a6cd3ea)

> 2 by 2 with 2 instances spaced evenly
> ![image](https://github.com/ajnart/homarr/assets/26098587/6621071e-1e3a-4171-a37e-eb70dd5e1563)

> With buttons, unchanged
> ![image](https://github.com/ajnart/homarr/assets/26098587/3f8a53ed-6ad9-4a19-ba20-e6b77986b82c)
