### PR TITLE
🩺  Added healthcheck to image and ARG for port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 
+ARG PORT=7575
+
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NODE_ENV production
 ENV NODE_OPTIONS '--no-experimental-fetch'
@@ -14,8 +16,10 @@ COPY package.json ./package.json
 COPY .next/standalone ./
 COPY .next/static ./.next/static
 
-EXPOSE 7575
+EXPOSE $PORT
+ENV PORT=${PORT}
 
-ENV PORT 7575
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT} || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
### Category
Feature

### Overview
- Added ``HEALTHCHECK`` to Dockerfile that simply sends a HTTP request to the Entrypoint of Homarr via ``wget`` in spider mode (Intervals are set quite low because Homarr only serves a simple web server with static compiled files)
- Added ``ARG`` for used port in Dockerfile to not have to define multiple times hardcoded (default ``7575``stays the same)

### Issue Number
Related issue: #1385 

### New Vars
Dockerfile ``ARG`` for used port added. (Default ``7575``). Makes Dockerfile more maintainable because Port has not to be hardcoded anymore in Dockerfile few times.

### Screenshots

![CleanShot 2023-09-09 at 10 37 10@2x](https://github.com/ajnart/homarr/assets/28538704/c4a8cdbb-341d-49ad-a65a-190fe02ff0e6)

``docker ps`` now shows container status as healthy (see above)