### PR TITLE
✨ Common troubleshoot and auto handling

### DIFF
--- a/public/locales/en/layout/modals/add-app.json
+++ b/public/locales/en/layout/modals/add-app.json
@@ -13,7 +13,18 @@
 		},
 		"internalAddress": {
 			"label": "Internal address",
-			"description": "Internal IP-address of the app."
+			"description": "Internal IP-address of the app.",
+			"troubleshoot": {
+				"label": "Common Troubleshooting",
+				"header": "This is a list of commonly made mistake and troubleshooting:",
+				"lines": {
+					"nothingAfterPort": "You should, in most if not all cases, not input anything after the port, even the '/admin' for pihole.",
+					"protocolCheck": "Always make sure that the URL is preceded by http or https, and to make sure you are using the right one.",
+					"iframe": "When it comes to iframes, those should always be using the same protocol (http/s) as Homarr.",
+					"clearCache": "Some informations are registered in cache, so an integration might not work unless you clear the cache in Homarr's general options."
+				},
+				"footer": "For more troubleshooting, reach out on our {{discord}}."
+			}
 		},
 		"externalAddress": {
 			"label": "External address",

--- a/src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/EditAppModal.tsx
@@ -11,11 +11,12 @@ import {
   IconPlug,
 } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
+import { removeTrailingSlash } from 'next/dist/shared/lib/router/utils/remove-trailing-slash';
 import { useState } from 'react';
-
 import { useConfigContext } from '~/config/provider';
 import { useConfigStore } from '~/config/store';
 import { AppType } from '~/types/app';
+
 import { DebouncedImage } from '../../../IconSelector/DebouncedImage';
 import { useEditModeStore } from '../../Views/useEditModeStore';
 import { AppearanceTab } from './Tabs/AppereanceTab/AppereanceTab';
@@ -89,6 +90,9 @@ export const EditAppModal = ({
     if (!configName) {
       return;
     }
+
+    values.url = removeTrailingSlash(values.url);
+    values.behaviour.externalUrl = removeTrailingSlash(values.behaviour.externalUrl);
 
     updateConfig(
       configName,

--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/GeneralTab/GeneralTab.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/GeneralTab/GeneralTab.tsx
@@ -1,9 +1,10 @@
-import { Stack, Tabs, Text, TextInput } from '@mantine/core';
+import { Anchor, Button, Card, Collapse, Group, Stack, Tabs, Text, TextInput } from '@mantine/core';
 import { UseFormReturnType } from '@mantine/form';
-import { IconClick, IconCursorText, IconLink } from '@tabler/icons-react';
+import { useDisclosure } from '@mantine/hooks';
+import { IconAlertCircle, IconClick, IconCursorText, IconLink } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
-
 import { AppType } from '~/types/app';
+
 import { EditAppModalTab } from '../type';
 
 interface GeneralTabProps {
@@ -13,6 +14,16 @@ interface GeneralTabProps {
 
 export const GeneralTab = ({ form, openTab }: GeneralTabProps) => {
   const { t } = useTranslation('layout/modals/add-app');
+
+  const [opened, { toggle }] = useDisclosure(false);
+
+  const commonMistakes = [
+    t('general.internalAddress.troubleshoot.lines.nothingAfterPort'),
+    t('general.internalAddress.troubleshoot.lines.protocolCheck'),
+    t('general.internalAddress.troubleshoot.lines.iframe'),
+    t('general.internalAddress.troubleshoot.lines.clearCache'),
+  ];
+
   return (
     <Tabs.Panel value="general" pt="sm">
       <Stack spacing="xs">
@@ -46,12 +57,39 @@ export const GeneralTab = ({ form, openTab }: GeneralTabProps) => {
           {...form.getInputProps('behaviour.externalUrl')}
         />
 
+        <Group position="right" mt={22}>
+          <Button rightIcon={<IconAlertCircle />} onClick={toggle}>
+            {t('general.internalAddress.troubleshoot.label')}
+          </Button>
+        </Group>
+
+        <Collapse in={opened}>
+          <Card withBorder>
+            <Text>{t('general.internalAddress.troubleshoot.header')}</Text>
+            {commonMistakes.map((value: string, key: number) => {
+              return (
+                <Group key={key} display="flex" style={{ alignItems: 'start' }}>
+                  <Text>•</Text>
+                  <Text style={{ flex: '1' }}>{value}</Text>
+                </Group>
+              );
+            })}
+            <Text>
+              {t('general.internalAddress.troubleshoot.footer').split('{{discord}}')[0]}
+              <Anchor href="https://discord.gg/aCsmEV5RgA" target="_blank">
+                Discord
+              </Anchor>
+              {t('general.internalAddress.troubleshoot.footer').split('{{discord}}')[1]}
+            </Text>
+          </Card>
+        </Collapse>
+
         {!form.values.behaviour.externalUrl.startsWith('https://') &&
           !form.values.behaviour.externalUrl.startsWith('http://') && (
             <Text color="red" mt="sm" size="sm">
               {t('behaviour.customProtocolWarning')}
             </Text>
-        )}
+          )}
       </Stack>
     </Tabs.Panel>
   );


### PR DESCRIPTION
### Category
> Feature

### Overview
> Automatically removes the trailing slash when saving an app on both internal and external URLS.
> Doesn't remove path since some user config might actually require it.

> Add a button with collapsible section on the first tab of the app settings with common troubleshooting.
> troubleshooting list also includes some lightly out of context advice/troubleshooting as the app is the center of integration in general as well.

### Issue Number
> Closes #1391 

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/0307d6a1-bad5-439b-b421-e2bdb9055612)