### PR TITLE
💄 Change modal for Calendar

### DIFF
--- a/src/widgets/calendar/CalendarDay.tsx
+++ b/src/widgets/calendar/CalendarDay.tsx
@@ -65,7 +65,7 @@ export const CalendarDay = ({ date, medias, size }: CalendarDayProps) => {
     >
       <Popover.Target>
         <Container
-          onClick={medias.totalCount > 0 ? open : undefined}
+          onClick={medias.totalCount > 0 && !opened ? open : close}
           h="100%"
           w="100%"
           sx={{


### PR DESCRIPTION
### Category
> Cosmetic

### Overview
> Add the possibility to close the popover when clicking the target to make it behave like a normal popover would.

> Target: all modals on tap/click in a popover, for Media-server, Calendar and torrent download

### Issue Number
> Related issue: #1348