### PR TITLE
💄 Change modal for torrent widget

### DIFF
--- a/src/widgets/torrent/TorrentQueueItem.tsx
+++ b/src/widgets/torrent/TorrentQueueItem.tsx
@@ -13,7 +13,6 @@ import {
   createStyles,
   useMantineTheme,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import {
   IconAffiliate,
   IconDatabase,
@@ -26,7 +25,6 @@ import {
 } from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
 import { MIN_WIDTH_MOBILE } from '~/constants/constants';
-
 import { calculateETA } from '~/tools/client/calculateEta';
 import { humanFileSize } from '~/tools/humanFileSize';
 import { AppType } from '~/types/app';
@@ -38,7 +36,6 @@ interface TorrentQueueItemProps {
 }
 
 export const BitTorrentQueueItem = ({ torrent, width, app }: TorrentQueueItemProps) => {
-  const [popoverOpened, { open: openPopover, close: closePopover }] = useDisclosure(false);
   const { classes } = useStyles();
   const { t } = useTranslation('modules/torrents-status');
 
@@ -46,71 +43,79 @@ export const BitTorrentQueueItem = ({ torrent, width, app }: TorrentQueueItemPro
   const uploadSpeed = torrent.uploadSpeed / 1024 / 1024;
   const size = torrent.totalSelected;
   return (
-    <tr key={torrent.id} className={classes.transparentBackground}>
-      <td>
-        <Popover opened={popoverOpened} radius="md" shadow="md" width={350} withinPortal>
-          <Popover.Dropdown>
-            <TorrentQueuePopover torrent={torrent} app={app} />
-          </Popover.Dropdown>
-          <Popover.Target>
-            <div onMouseEnter={openPopover} onMouseLeave={closePopover}>
-              <Text
-                style={{
-                  maxWidth: '30vw',
-                }}
-                size="xs"
-                lineClamp={1}
-              >
-                {torrent.name}
+    <Popover
+      withArrow
+      withinPortal
+      radius="lg"
+      shadow="sm"
+      transitionProps={{
+        transition: 'pop',
+      }}
+    >
+      <Popover.Target>
+        <tr key={torrent.id} style={{ cursor: 'pointer' }}>
+          <td>
+            <Text
+              style={{
+                maxWidth: '30vw',
+              }}
+              size="xs"
+              lineClamp={1}
+            >
+              {torrent.name}
+            </Text>
+            {app && (
+              <Text size="xs" color="dimmed">
+                {t('card.table.item.text', {
+                  appName: app.name,
+                  ratio: torrent.ratio.toFixed(2),
+                })}
               </Text>
-              {app && (
-                <Text size="xs" color="dimmed">
-                  {t('card.table.item.text', {
-                    appName: app.name,
-                    ratio: torrent.ratio.toFixed(2),
-                  })}
-                </Text>
-              )}
-            </div>
-          </Popover.Target>
-        </Popover>
-      </td>
-      <td>
-        <Text className={classes.noTextBreak} size="xs">
-          {humanFileSize(size, false)}
-        </Text>
-      </td>
-      {width > MIN_WIDTH_MOBILE && (
-        <td>
-          <Text className={classes.noTextBreak} size="xs">
-            {downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} Mb/s` : '-'}
-          </Text>
-        </td>
-      )}
-      {width > MIN_WIDTH_MOBILE && (
-        <td>
-          <Text className={classes.noTextBreak} size="xs">
-            {uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} Mb/s` : '-'}
-          </Text>
-        </td>
-      )}
-      {width > MIN_WIDTH_MOBILE && (
-        <td>
-          <Text className={classes.noTextBreak} size="xs">
-            {torrent.eta <= 0 ? '∞' : calculateETA(torrent.eta)}
-          </Text>
-        </td>
-      )}
-      <td>
-        <Text className={classes.noTextBreak}>{(torrent.progress * 100).toFixed(1)}%</Text>
-        <Progress
-          radius="lg"
-          color={torrent.progress === 1 ? 'green' : torrent.state === 'paused' ? 'yellow' : 'blue'}
-          value={torrent.progress * 100}
-          size="lg"
-        />
-      </td>
-    </tr>
+            )}
+          </td>
+          <td>
+            <Text className={classes.noTextBreak} size="xs">
+              {humanFileSize(size, false)}
+            </Text>
+          </td>
+          {width > MIN_WIDTH_MOBILE && (
+            <td>
+              <Text className={classes.noTextBreak} size="xs">
+                {downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} Mb/s` : '-'}
+              </Text>
+            </td>
+          )}
+          {width > MIN_WIDTH_MOBILE && (
+            <td>
+              <Text className={classes.noTextBreak} size="xs">
+                {uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} Mb/s` : '-'}
+              </Text>
+            </td>
+          )}
+          {width > MIN_WIDTH_MOBILE && (
+            <td>
+              <Text className={classes.noTextBreak} size="xs">
+                {torrent.eta <= 0 ? '∞' : calculateETA(torrent.eta)}
+              </Text>
+            </td>
+          )}
+          <td>
+            <Text className={classes.noTextBreak}>{(torrent.progress * 100).toFixed(1)}%</Text>
+            <Progress
+              radius="lg"
+              color={
+                torrent.progress === 1 ? 'green' : torrent.state === 'paused' ? 'yellow' : 'blue'
+              }
+              value={torrent.progress * 100}
+              size="lg"
+            />
+          </td>
+        </tr>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <TorrentQueuePopover torrent={torrent} app={app} />
+      </Popover.Dropdown>
+    </Popover>
   );
 };
 
@@ -233,8 +238,5 @@ const TorrentQueuePopover = ({ torrent, app }: Omit<TorrentQueueItemProps, 'widt
 const useStyles = createStyles(() => ({
   noTextBreak: {
     whiteSpace: 'nowrap',
-  },
-  transparentBackground: {
-    backgroundColor: 'transparent !important',
   },
 }));


### PR DESCRIPTION
### Category
> Cosmetic

### Overview
> Made the modal popover on click instead of on hover.
> Apply to full row instead of title.
> Restored line highlight on hover.

> Target: all modals on tap/click in a popover, for Media-server, Calendar and torrent download

### Issue Number
> Related issue: #1348

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/86897927-932b-4024-a1b3-7e4e8bc69303)
