### PR TITLE
💄 Added modal for usenet widget

### DIFF
--- a/src/widgets/useNet/UsenetHistoryList.tsx
+++ b/src/widgets/useNet/UsenetHistoryList.tsx
@@ -3,24 +3,25 @@ import {
   Center,
   Code,
   Group,
+  List,
   Pagination,
+  Popover,
   Skeleton,
   Stack,
   Table,
   Text,
   Title,
-  Tooltip,
 } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { IconAlertCircle, IconClock, IconFileDownload, IconFileInfo } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import { useTranslation } from 'next-i18next';
 import { FunctionComponent, useState } from 'react';
-
-import { useGetUsenetHistory } from '../dashDot/api';
 import { parseDuration } from '~/tools/client/parseDuration';
 import { humanFileSize } from '~/tools/humanFileSize';
+
+import { useGetUsenetHistory } from '../dashDot/api';
 
 dayjs.extend(duration);
 
@@ -87,37 +88,58 @@ export const UsenetHistoryList: FunctionComponent<UsenetHistoryListProps> = ({ a
           <tr>
             <th>{t('modules/usenet:history.header.name')}</th>
             <th style={{ width: 100 }}>{t('modules/usenet:history.header.size')}</th>
-            {durationBreakpoint < width ? (
+            {durationBreakpoint < width && (
               <th style={{ width: 200 }}>{t('modules/usenet:history.header.duration')}</th>
-            ) : null}
+            )}
           </tr>
         </thead>
         <tbody>
           {data.items.map((history) => (
-            <tr key={history.id}>
-              <td>
-                <Tooltip position="top" label={history.name}>
-                  <Text
-                    size="xs"
-                    style={{
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
-                    {history.name}
-                  </Text>
-                </Tooltip>
-              </td>
-              <td>
-                <Text size="xs">{humanFileSize(history.size)}</Text>
-              </td>
-              {durationBreakpoint < width ? (
-                <td>
-                  <Text size="xs">{parseDuration(history.time, t)}</Text>
-                </td>
-              ) : null}
-            </tr>
+            <Popover
+              withArrow
+              withinPortal
+              radius="lg"
+              shadow="sm"
+              transitionProps={{
+                transition: 'pop',
+              }}
+            >
+              <Popover.Target>
+                <tr key={history.id}>
+                  <td>
+                    <Text
+                      size="xs"
+                      style={{
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {history.name}
+                    </Text>
+                  </td>
+                  <td>
+                    <Text size="xs">{humanFileSize(history.size)}</Text>
+                  </td>
+                  {durationBreakpoint < width && (
+                    <td>
+                      <Text size="xs">{parseDuration(history.time, t)}</Text>
+                    </td>
+                  )}
+                </tr>
+              </Popover.Target>
+              <Popover.Dropdown>
+                <List>
+                  <List.Item icon={<IconFileInfo size={16} />}>{history.name}</List.Item>
+                  <List.Item icon={<IconClock size={16} />}>
+                    {parseDuration(history.time, t)}
+                  </List.Item>
+                  <List.Item icon={<IconFileDownload size={16} />}>
+                    {humanFileSize(history.size)}
+                  </List.Item>
+                </List>
+              </Popover.Dropdown>
+            </Popover>
           ))}
         </tbody>
       </Table>

--- a/src/widgets/useNet/UsenetQueueList.tsx
+++ b/src/widgets/useNet/UsenetQueueList.tsx
@@ -1,27 +1,35 @@
 import {
-  ActionIcon,
   Alert,
   Center,
   Code,
   Group,
+  List,
   Pagination,
+  Popover,
   Progress,
   Skeleton,
   Stack,
   Table,
   Text,
   Title,
-  Tooltip,
   useMantineTheme,
 } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
-import { IconAlertCircle, IconPlayerPause, IconPlayerPlay } from '@tabler/icons-react';
+import {
+  IconAlertCircle,
+  IconClock,
+  IconClockPause,
+  IconFileDownload,
+  IconFileInfo,
+  IconPercentage,
+} from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import { useTranslation } from 'next-i18next';
 import { FunctionComponent, useState } from 'react';
-
+import { parseDuration } from '~/tools/client/parseDuration';
 import { humanFileSize } from '~/tools/humanFileSize';
+
 import { useGetUsenetDownloads } from '../dashDot/api';
 
 dayjs.extend(duration);
@@ -105,53 +113,81 @@ export const UsenetQueueList: FunctionComponent<UsenetQueueListProps> = ({ appId
         </thead>
         <tbody>
           {data.items.map((nzb) => (
-            <tr key={nzb.id}>
-              <td>
-                <Tooltip position="top" label={nzb.name}>
-                  <Text
-                    style={{
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                    size="xs"
-                    color={nzb.state === 'paused' ? 'dimmed' : undefined}
-                  >
-                    {nzb.name}
-                  </Text>
-                </Tooltip>
-              </td>
-              {sizeBreakpoint < width ? (
-                <td>
-                  <Text size="xs">{humanFileSize(nzb.size)}</Text>
-                </td>
-              ) : null}
-              <td>
-                {nzb.eta <= 0 ? (
-                  <Text size="xs" color="dimmed">
-                    {t('queue.paused')}
-                  </Text>
-                ) : (
-                  <Text size="xs">{dayjs.duration(nzb.eta, 's').format('H:mm:ss')}</Text>
-                )}
-              </td>
-              {progressBreakpoint < width ? (
-                <td style={{ display: 'flex', alignItems: 'center' }}>
-                  <Text mr="sm" style={{ whiteSpace: 'nowrap' }}>
-                    {nzb.progress.toFixed(1)}%
-                  </Text>
-                  {width > progressbarBreakpoint ? (
-                    <Progress
-                      radius="lg"
-                      color={nzb.eta > 0 ? theme.primaryColor : 'lightgrey'}
-                      value={nzb.progress}
-                      size="lg"
-                      style={{ width: '100%' }}
-                    />
+            <Popover
+              withArrow
+              withinPortal
+              radius="lg"
+              shadow="sm"
+              transitionProps={{
+                transition: 'pop',
+              }}
+            >
+              <Popover.Target>
+                <tr key={nzb.id}>
+                  <td>
+                    <Text
+                      style={{
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                      size="xs"
+                      color={nzb.state === 'paused' ? 'dimmed' : undefined}
+                    >
+                      {nzb.name}
+                    </Text>
+                  </td>
+                  {sizeBreakpoint < width ? (
+                    <td>
+                      <Text size="xs">{humanFileSize(nzb.size)}</Text>
+                    </td>
                   ) : null}
-                </td>
-              ) : null}
-            </tr>
+                  <td>
+                    {nzb.eta <= 0 ? (
+                      <Text size="xs" color="dimmed">
+                        {t('queue.paused')}
+                      </Text>
+                    ) : (
+                      <Text size="xs">{dayjs.duration(nzb.eta, 's').format('H:mm:ss')}</Text>
+                    )}
+                  </td>
+                  {progressBreakpoint < width ? (
+                    <td style={{ display: 'flex', alignItems: 'center' }}>
+                      <Text mr="sm" style={{ whiteSpace: 'nowrap' }}>
+                        {nzb.progress.toFixed(1)}%
+                      </Text>
+                      {width > progressbarBreakpoint ? (
+                        <Progress
+                          radius="lg"
+                          color={nzb.eta > 0 ? theme.primaryColor : 'lightgrey'}
+                          value={nzb.progress}
+                          size="lg"
+                          style={{ width: '100%' }}
+                        />
+                      ) : null}
+                    </td>
+                  ) : null}
+                </tr>
+              </Popover.Target>
+              <Popover.Dropdown>
+                <List>
+                  <List.Item icon={<IconFileInfo size={16} />}>{nzb.name}</List.Item>
+                  <List.Item icon={<IconPercentage size={16} />}>
+                    {nzb.progress.toFixed(1)}%
+                  </List.Item>
+                  {nzb.state === 'downloading' ? (
+                    <List.Item icon={<IconClock size={16} />}>
+                      {parseDuration(nzb.eta, t)}
+                    </List.Item>
+                  ) : (
+                    <List.Item icon={<IconClockPause size={16} />}>{t('queue.paused')}</List.Item>
+                  )}
+                  <List.Item icon={<IconFileDownload size={16} />}>
+                    {humanFileSize(nzb.size)}
+                  </List.Item>
+                </List>
+              </Popover.Dropdown>
+            </Popover>
           ))}
         </tbody>
       </Table>


### PR DESCRIPTION
### Category
> Cosmetic

### Overview
> As the torrent widget has a modal, and the usenet widget has a tooltip on hover, this adds an actual modal to the usenet widget on both the queue and the history tabs instead of aforementioned tooltip.
> Modal shows all the infos the widget naturally shows on it's largest setting, providing those information when the widget is too narrow to contain them.

> Target: all modals on tap/click in a popover, for Media-server, Calendar and torrent download

### Issue Number
> Related issue: #1348

### Screenshot
>![image](https://github.com/ajnart/homarr/assets/26098587/877a0f71-a8df-4928-a903-2b47c4c77416)

> ![image](https://github.com/ajnart/homarr/assets/26098587/89282b15-9f1e-43ac-96a1-434a717259cc)

