### PR TITLE
🐛 Download speed widget nzbget fix

### DIFF
--- a/src/server/api/routers/download.ts
+++ b/src/server/api/routers/download.ts
@@ -206,7 +206,7 @@ const GetDataFromClient = async (
         appId: app.id,
         nzbs: nzbgetItems,
         success: true,
-        totalDownload: 0,
+        totalDownload: nzbgetStatus.DownloadRate,
       };
     }
     default:


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> totalDownload is the field used by other integrations for the download speed. Bit of weird naming and made it hard to find.
> It was returning a fixed 0 for nzbget instead of downloadRate.

### Issue Number
> Closes #1394