### PR TITLE
🐛 Calendar indicator over header bar fix

### DIFF
--- a/src/widgets/calendar/CalendarDay.tsx
+++ b/src/widgets/calendar/CalendarDay.tsx
@@ -131,7 +131,7 @@ const DayIndicator = ({ size, offset, color, medias, children, position }: DayIn
   if (medias.length === 0) return children;
 
   return (
-    <Indicator size={size} withBorder offset={offset} color={color} position={position}>
+    <Indicator size={size} withBorder offset={offset} color={color} position={position} zIndex={0}>
       {children}
     </Indicator>
   );


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Calendar indicators would appear on top of the header bar.

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/e157e10a-a324-4ab4-b500-78ac6bfd8508)

