### PR TITLE
🐛 DNS-Hole error handling and fixes

### DIFF
--- a/public/locales/en/modules/dns-hole-controls.json
+++ b/public/locales/en/modules/dns-hole-controls.json
@@ -1,6 +1,12 @@
 {
   "descriptor": {
     "name": "DNS hole controls",
-    "description": "Control PiHole or AdGuard from your dashboard"
+    "description": "Control PiHole or AdGuard from your dashboard",
+    "errors": {
+      "general": {
+        "title": "Unable to find a DNS hole",
+        "text": "There was a problem connecting to your DNS Hole(s). Please verify your configuration/integration(s)."
+      }
+    }
   }
 }

--- a/src/tools/server/sdk/adGuard/adGuard.schema.ts
+++ b/src/tools/server/sdk/adGuard/adGuard.schema.ts
@@ -32,7 +32,7 @@ export const adGuardApiStatusResponseSchema = z.object({
 export const adGuardApiFilteringStatusSchema = z.object({
   filters: z.array(
     z.object({
-      url: z.string().url(),
+      url: z.string(),
       name: z.string(),
       last_updated: z.string().optional(),
       id: z.number().nonnegative(),

--- a/src/widgets/dnshole/DnsHoleControls.tsx
+++ b/src/widgets/dnshole/DnsHoleControls.tsx
@@ -3,11 +3,13 @@ import {
   Box,
   Button,
   Card,
+  Center,
   Group,
   Image,
   SimpleGrid,
   Stack,
   Text,
+  Title,
   UnstyledButton,
 } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
@@ -66,7 +68,7 @@ function DnsHoleControlsWidgetTile({ widget }: DnsHoleControlsWidgetProps) {
   const { isInitialLoading, data, isFetching: fetchingDnsSummary } = useDnsHoleSummeryQuery();
   const { mutateAsync, isLoading: changingStatus } = useDnsHoleControlMutation();
   const { width, ref } = useElementSize();
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(['common', 'modules/dns-hole-controls']);
 
   const { name: configName, config } = useConfigContext();
 
@@ -75,6 +77,20 @@ function DnsHoleControlsWidgetTile({ widget }: DnsHoleControlsWidgetProps) {
   if (isInitialLoading || !data || !configName) {
     return <WidgetLoading />;
   }
+
+  if (data.status.length === 0) {
+    return(
+      <Center h="100%">
+        <Stack align="center">
+          <IconDeviceGamepad size={40} strokeWidth={1}/>
+          <Title align="center" order={6}>{t('modules/dns-hole-controls:descriptor.errors.general.title')}</Title>
+          <Text align="center">{t('modules/dns-hole-controls:descriptor.errors.general.text')}</Text>
+        </Stack>
+      </Center>
+    )
+  }
+
+  console.log(data);
 
   type getDnsStatusAcc = {
     enabled: string[];


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> url field in the adGuard filtering status schema required string to be an actual url which blocked local filepath.
> Also handles errors thrown as indicator to ignore app in dnshole widget so they don't get stuck in loading with multiple instances.
> Replace load loop with error tile to inform user of a problem.
> Errors will still show in console for debugging.

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/29ef0ffd-2509-4360-8baf-aea7b85c6717)
