### PR TITLE
🐛 Change position selector's dropdown bug

### DIFF
--- a/src/components/Dashboard/Modals/ChangePosition/ChangePositionModal.tsx
+++ b/src/components/Dashboard/Modals/ChangePosition/ChangePositionModal.tsx
@@ -95,6 +95,7 @@ export const ChangePositionModal = ({
               min: widthData.at(0)?.label,
               max: widthData.at(-1)?.label,
             })}
+            withinPortal
             {...form.getInputProps('width')}
           />
         </Grid.Col>
@@ -109,6 +110,7 @@ export const ChangePositionModal = ({
               min: heightData.at(0)?.label,
               max: heightData.at(-1)?.label,
             })}
+            withinPortal
             {...form.getInputProps('height')}
           />
         </Grid.Col>


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Selectors' dropdowns in the "change position" edit menu were cut off.

### Issue Number
> Discord report

### Screenshot
> Before
> ![image](https://github.com/ajnart/homarr/assets/26098587/dd45707f-f4b0-49b3-b5ed-3acf48cdadf3)


> After
> ![image](https://github.com/ajnart/homarr/assets/26098587/a6c15fa8-65f5-4642-adfb-15b3b7ee9c95)

