### PR TITLE
🗃️ Add missing binary targets to prisma orm

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
     provider      = "prisma-client-js"
-    binaryTargets = ["native", "linux-musl-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x", "debian-openssl-3.0.x"]
+    binaryTargets = ["native", "windows", "linux-musl-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b45d63f</samp>

Updated the Prisma client configuration to support Windows as a binary target. This fixes a bug that prevented the client from working on Windows machines.

Potential fix for #1428