### PR TITLE
fix: stop triming traling slashes

### DIFF
--- a/src/components/Dashboard/Tiles/Apps/AppTile.tsx
+++ b/src/components/Dashboard/Tiles/Apps/AppTile.tsx
@@ -87,7 +87,7 @@ export const AppTile = ({ className, app }: AppTileProps) => {
       ) : (
         <UnstyledButton
           style={{ pointerEvents: isEditMode ? 'none' : 'auto' }}
-          component={Link}
+          component="a"
           href={app.behaviour.externalUrl.length > 0 ? app.behaviour.externalUrl : app.url}
           target={app.behaviour.isOpeningNewTab ? '_blank' : '_self'}
           className={`${classes.button} ${classes.base}`}


### PR DESCRIPTION
### Category
Bugfix

### Overview
Change app tile to use `a` component in the button link instead of the `link` component.

### Issue Number _(if applicable)_
#777