### PR TITLE
🐛 Background image not visible, remove background image from default config

### DIFF
--- a/data/configs/default.json
+++ b/data/configs/default.json
@@ -492,7 +492,7 @@
       "pageTitle": "Homarr ⭐️",
       "logoImageUrl": "/imgs/logo/logo.png",
       "faviconUrl": "/imgs/favicon/favicon-squared.png",
-      "backgroundImageUrl": "https://images.unsplash.com/32/Mc8kW4x9Q3aRR3RkP5Im_IMG_4417.jpg?ixid=M3wxMjA3fDB8MXxzZWFyY2h8MTV8fGJhY2tncm91bmQlMjBpbWFnZXxlbnwwfHx8fDE2OTE0NDQ5NjF8MA&ixlib=rb-4.0.3",
+      "backgroundImageUrl": "",
       "customCss": "",
       "colors": {
         "primary": "red",

--- a/src/components/layout/Templates/BoardLayout.tsx
+++ b/src/components/layout/Templates/BoardLayout.tsx
@@ -218,7 +218,7 @@ const BackgroundImage = () => {
   return (
     <Global
       styles={{
-        body: {
+        '.mantine-AppShell-root': {
           minHeight: '100vh',
           backgroundImage: `url('${config?.settings.customization.backgroundImageUrl}')`,
           backgroundPosition: 'center center',


### PR DESCRIPTION
The root app shell has a background color now. Because of that we need to set the background image on it instead of the body. Additionally in the default config was a background image that was added acidentally durring the auth update.