### PR TITLE
feat: add support for default ports on http(s) protocols on download.ts

### DIFF
--- a/src/server/api/routers/download.ts
+++ b/src/server/api/routers/download.ts
@@ -156,7 +156,7 @@ const GetDataFromClient = async (
       const url = new URL(app.url);
       const options = {
         host: url.hostname,
-        port: url.port,
+        port: url.port || (url.protocol === 'https:' ? '443' : '80'),
         login: findAppProperty(app, 'username'),
         hash: findAppProperty(app, 'password'),
       };


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
> Bugfix

### Overview
> For internal ip/urls if the application exists on port 80 or 443. new Url will not set port. So this will add defaults based on protocol for http or https.

### Issue Number _(if applicable)_
> Related issue: #642

### New Vars _(if applicable)_
> n/a

### Screenshot _(if applicable)_
> n/a