### PR TITLE
🐛 adguard removed max test on process time

### DIFF
--- a/src/tools/server/sdk/adGuard/adGuard.schema.ts
+++ b/src/tools/server/sdk/adGuard/adGuard.schema.ts
@@ -14,7 +14,7 @@ export const adGuardApiStatsResponseSchema = z.object({
   num_replaced_safebrowsing: z.number().min(0),
   num_replaced_safesearch: z.number().min(0),
   num_replaced_parental: z.number().min(0),
-  avg_processing_time: z.number().min(0).max(1),
+  avg_processing_time: z.number().min(0),
 });
 
 export const adGuardApiStatusResponseSchema = z.object({


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> AdGuard schema avg_processing_time can be more than 1. Removing max test.

### Issue Number
> https://discord.com/channels/972958686051962910/1167738919761231914