### PR TITLE
🐛Clock fix timezone named offset format for dayjs

### DIFF
--- a/src/widgets/date/DateTile.tsx
+++ b/src/widgets/date/DateTile.tsx
@@ -2,6 +2,7 @@ import { Stack, Text, createStyles } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
 import { IconClock } from '@tabler/icons-react';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import timezones from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import { useSession } from 'next-auth/react';
@@ -13,6 +14,7 @@ import { api } from '~/utils/api';
 import { defineWidget } from '../helper';
 import { IWidget } from '../widgets';
 
+dayjs.extend(advancedFormat);
 dayjs.extend(utc);
 dayjs.extend(timezones);
 


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Upon looking up a problem for one of our get-help issues, I noticed the timezone showing as "(z)" instead of it's named offset. Turns out dayjs needs a plugin to format that and it was forgotten when switching from moment.

### Screenshots
![image](https://github.com/ajnart/homarr/assets/26098587/3fae8835-3f38-4b03-93f9-e7d62050bd7d)
to
![image](https://github.com/ajnart/homarr/assets/26098587/419c013c-9e63-46fa-b97d-01474e58e325)
