### PR TITLE
Add an option to show active torrents when completed torrents are hidden in Torrent Queue widget

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/public/locales/en/modules/torrents-status.json
+++ b/public/locales/en/modules/torrents-status.json
@@ -10,6 +10,9 @@
       "displayCompletedTorrents": {
         "label": "Display completed torrents"
       },
+      "displayActiveTorrents": {
+        "label": "Show active torrents when completed torrents are hidden"
+      },
       "displayStaleTorrents": {
         "label": "Display stale torrents"
       },

--- a/public/locales/fr/modules/torrents-status.json
+++ b/public/locales/fr/modules/torrents-status.json
@@ -10,6 +10,9 @@
       "displayCompletedTorrents": {
         "label": "Cacher les torrents terminés"
       },
+      "displayActiveTorrents": {
+        "label": "Afficher les torrents actifs quand les torrents terminés sont masqués"
+      },
       "displayStaleTorrents": {
         "label": "Afficher les torrents périmés"
       },

--- a/src/widgets/torrent/TorrentTile.spec.ts
+++ b/src/widgets/torrent/TorrentTile.spec.ts
@@ -20,13 +20,14 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: true,
+        displayActiveTorrents: true,
         displayStaleTorrents: false,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672),
-      constructTorrent('HH', 'I am completed', true, 0),
-      constructTorrent('HH', 'I am stale', false, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 0),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
     ];
 
     // act
@@ -55,13 +56,14 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: true,
+        displayActiveTorrents: true,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672),
-      constructTorrent('HH', 'I am completed', true, 0),
-      constructTorrent('HH', 'I am stale', false, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 0),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
     ];
 
     // act
@@ -74,7 +76,7 @@ describe('TorrentTile', () => {
     expect(filtered.includes(torrents[2])).toBe(true);
   });
 
-  it('filter when completed', () => {
+  it('filter when completed without active torrent', () => {
     // arrange
     const widget: ITorrent = {
       id: 'abc',
@@ -90,13 +92,14 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: false,
+        displayActiveTorrents: false,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672),
-      constructTorrent('HH', 'I am completed', true, 0),
-      constructTorrent('HH', 'I am stale', false, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 672),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
     ];
 
     // act
@@ -107,6 +110,44 @@ describe('TorrentTile', () => {
     expect(filtered.at(0)).toBe(torrents[0]);
     expect(filtered.includes(torrents[1])).toBe(false);
     expect(filtered.at(1)).toBe(torrents[2]);
+  });
+
+  it('filter when completed with active torrent', () => {
+    // arrange
+    const widget: ITorrent = {
+      id: 'abc',
+      area: {
+        type: 'sidebar',
+        properties: {
+          location: 'left',
+        },
+      },
+      shape: {},
+      type: 'torrents-status',
+      properties: {
+        labelFilter: [],
+        labelFilterIsWhitelist: false,
+        displayCompletedTorrents: false,
+        displayActiveTorrents: true,
+        displayStaleTorrents: true,
+      },
+    };
+    const torrents: NormalizedTorrent[] = [
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed and uploading', true, 0, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 0),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
+    ];
+
+    // act
+    const filtered = filterTorrents(widget, torrents);
+
+    // assert
+    expect(filtered.length).toBe(3);
+    expect(filtered.at(0)).toBe(torrents[0]);
+    expect(filtered.at(1)).toBe(torrents[1]);
+    expect(filtered.includes(torrents[2])).toBe(false);
+    expect(filtered.at(2)).toBe(torrents[3]);
   });
 
   it('filter by label when whitelist', () => {
@@ -125,13 +166,14 @@ describe('TorrentTile', () => {
         labelFilter: ['music', 'movie'],
         labelFilterIsWhitelist: true,
         displayCompletedTorrents: true,
+        displayActiveTorrents: true,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('1', 'A sick drop', false, 672, 'music'),
-      constructTorrent('2', 'I cried', true, 0, 'movie'),
-      constructTorrent('3', 'Great Animations', false, 0, 'anime'),
+      constructTorrent('1', 'A sick drop', false, 672, 672, 'music'),
+      constructTorrent('2', 'I cried', true, 0, 0, 'movie'),
+      constructTorrent('3', 'Great Animations', false, 0, 0, 'anime'),
     ];
 
     // act
@@ -160,13 +202,14 @@ describe('TorrentTile', () => {
         labelFilter: ['music', 'movie'],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: false,
+        displayActiveTorrents: false,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 'anime'),
-      constructTorrent('HH', 'I am completed', true, 0, 'movie'),
-      constructTorrent('HH', 'I am stale', false, 0, 'tv'),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672, 'anime'),
+      constructTorrent('HH', 'I am completed', true, 0, 0, 'movie'),
+      constructTorrent('HH', 'I am stale', false, 0, 0, 'tv'),
     ];
 
     // act
@@ -185,6 +228,7 @@ const constructTorrent = (
   name: string,
   isCompleted: boolean,
   downloadSpeed: number,
+  uploadSpeed: number,
   label?: string
 ): NormalizedTorrent => ({
   id,

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -40,6 +40,10 @@ const definition = defineWidget({
       type: 'switch',
       defaultValue: true,
     },
+    displayActiveTorrents: {
+      type: 'switch',
+      defaultValue: true,
+    },
     displayStaleTorrents: {
       type: 'switch',
       defaultValue: true,
@@ -194,7 +198,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
 export const filterTorrents = (widget: ITorrent, torrents: NormalizedTorrent[]) => {
   let result = torrents;
   if (!widget.properties.displayCompletedTorrents) {
-    result = result.filter((torrent) => !torrent.isCompleted);
+    result = result.filter((torrent) => !torrent.isCompleted || (widget.properties.displayActiveTorrents && torrent.uploadSpeed > 0));
   }
 
   if (widget.properties.labelFilter.length > 0) {


### PR DESCRIPTION
### Category
> Feature

### Overview
> Add an option to show active torrents when completed torrents are hidden :
> When 'Display completed torrents' is disable and 'Show active torrents when completed torrents are hidden' is enable, the widget will show downloading torrents and torrents with uploadspeed not null
> No change when 'Display completed torrents' is enable

### New Vars
>  [bool] widget.properties.displayActiveTorrents

### Screenshot
![image](https://github.com/ajnart/homarr/assets/10882916/0e831cc5-f308-42f5-8ebb-270c44f4963b)
![image](https://github.com/ajnart/homarr/assets/10882916/0bd3bea1-8b52-40c6-a020-e196c6bc5ac8)

### Comment
If someone know how to hide this option when "Display completed torrents" is on, feel free to update