### PR TITLE
Fix Mb/s / MB/s conversion error in torrents speed

### DIFF
--- a/src/widgets/torrent/TorrentQueueItem.tsx
+++ b/src/widgets/torrent/TorrentQueueItem.tsx
@@ -81,14 +81,14 @@ export const BitTorrentQueueItem = ({ torrent, width, app }: TorrentQueueItemPro
           {width > MIN_WIDTH_MOBILE && (
             <td>
               <Text className={classes.noTextBreak} size="xs">
-                {downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} Mb/s` : '-'}
+                {downloadSpeed > 0 ? `${downloadSpeed.toFixed(1)} MB/s` : '-'}
               </Text>
             </td>
           )}
           {width > MIN_WIDTH_MOBILE && (
             <td>
               <Text className={classes.noTextBreak} size="xs">
-                {uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} Mb/s` : '-'}
+                {uploadSpeed > 0 ? `${uploadSpeed.toFixed(1)} MB/s` : '-'}
               </Text>
             </td>
           )}


### PR DESCRIPTION
The torrent speeds are currently displayed in Megabits per second, but @ctrl/shared-torrent is in Bytes. Therefore, they should be displayed in Megabytes per second, as they are only divided by 1024 twice

### Category
> Bugfix

### Overview
> Fix Mb/s / MB/s displayed error

### Issue Number
> Related issue: #488

### Screenshot _(if applicable)_
> Difference between qBittorrent and Homarr : (Mio/s = MiB/s ≈ MB/s = 8 Mb/s)
![image](https://github.com/ajnart/homarr/assets/10882916/4b60fc85-0732-4268-9fdf-3317ce9be7ec)

> @ctrl/shared-torrent doc :
![image](https://github.com/ajnart/homarr/assets/10882916/1d473db8-dade-4113-bc6e-1ca742350e0d)

> Conversion in Homarr :
![image](https://github.com/ajnart/homarr/assets/10882916/9feb58cd-1e0a-4731-a36a-7b75d86c3cd4)


