### PR TITLE
Add Torrents ratio in Torrents Queue Widget

### DIFF
--- a/public/locales/en/modules/torrents-status.json
+++ b/public/locales/en/modules/torrents-status.json
@@ -22,7 +22,7 @@
       },
       "displayRatioWithFilter": {
         "label": "Display filtered torrents list ratio",
-        "description": "If disabled, only the global ratio will be display. The global ratio will still use the labels if set"
+        "info": "If disabled, only the global ratio will be display. The global ratio will still use the labels if set"
       }
     }
   },

--- a/public/locales/en/modules/torrents-status.json
+++ b/public/locales/en/modules/torrents-status.json
@@ -21,8 +21,8 @@
         "description": "When 'is whitelist' checked, this will act as a whitelist. If not checked, this is a blacklist. Will not do anything when empty"
       },
       "displayRatioWithFilter": {
-        "label": "View filtered torrent list ratio",
-        "description": "When 'is whitelist' checked, this will act as a whitelist. If not checked, this is a blacklist. Will not do anything when empty"
+        "label": "Display filtered torrents list ratio",
+        "description": "If disable, only global ratio will be display. Global ratio still use labels if set"
       }
     }
   },

--- a/public/locales/en/modules/torrents-status.json
+++ b/public/locales/en/modules/torrents-status.json
@@ -19,13 +19,19 @@
       "labelFilter": {
         "label": "Label list",
         "description": "When 'is whitelist' checked, this will act as a whitelist. If not checked, this is a blacklist. Will not do anything when empty"
+      },
+      "displayRatioWithFilter": {
+        "label": "View filtered torrent list ratio",
+        "description": "When 'is whitelist' checked, this will act as a whitelist. If not checked, this is a blacklist. Will not do anything when empty"
       }
     }
   },
   "card": {
     "footer": {
       "error": "Error",
-      "lastUpdated": "Last updated {{time}} ago"
+      "lastUpdated": "Last updated {{time}} ago",
+      "ratioGlobal": "Global ratio",
+      "ratioWithFilter": "Ratio with filter"
     },
     "table": {
       "header": {

--- a/public/locales/en/modules/torrents-status.json
+++ b/public/locales/en/modules/torrents-status.json
@@ -22,7 +22,7 @@
       },
       "displayRatioWithFilter": {
         "label": "Display filtered torrents list ratio",
-        "description": "If disable, only global ratio will be display. Global ratio still use labels if set"
+        "description": "If disabled, only the global ratio will be display. The global ratio will still use the labels if set"
       }
     }
   },

--- a/src/widgets/torrent/TorrentTile.spec.ts
+++ b/src/widgets/torrent/TorrentTile.spec.ts
@@ -1,7 +1,7 @@
 import { NormalizedTorrent, TorrentState } from '@ctrl/shared-torrent';
 import { describe, expect, it } from 'vitest';
 
-import { ITorrent, filterTorrents } from './TorrentTile';
+import { ITorrent, filterTorrents, getTorrentsRatio } from './TorrentTile';
 
 describe('TorrentTile', () => {
   it('filter torrents when stale', () => {
@@ -20,13 +20,15 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: true,
+        displayActiveTorrents: true,
+        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: false,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672),
-      constructTorrent('HH', 'I am completed', true, 0),
-      constructTorrent('HH', 'I am stale', false, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 0),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
     ];
 
     // act
@@ -55,13 +57,15 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: true,
+        displayActiveTorrents: true,
+        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672),
-      constructTorrent('HH', 'I am completed', true, 0),
-      constructTorrent('HH', 'I am stale', false, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 0),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
     ];
 
     // act
@@ -74,7 +78,7 @@ describe('TorrentTile', () => {
     expect(filtered.includes(torrents[2])).toBe(true);
   });
 
-  it('filter when completed', () => {
+  it('filter when completed without active torrent', () => {
     // arrange
     const widget: ITorrent = {
       id: 'abc',
@@ -90,13 +94,15 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: false,
+        displayActiveTorrents: false,
+        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672),
-      constructTorrent('HH', 'I am completed', true, 0),
-      constructTorrent('HH', 'I am stale', false, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed', true, 0, 672),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
     ];
 
     // act
@@ -107,6 +113,47 @@ describe('TorrentTile', () => {
     expect(filtered.at(0)).toBe(torrents[0]);
     expect(filtered.includes(torrents[1])).toBe(false);
     expect(filtered.at(1)).toBe(torrents[2]);
+  });
+
+  it('filter when completed with active torrent', () => {
+    // arrange
+    const widget: ITorrent = {
+      id: 'abc',
+      area: {
+        type: 'sidebar',
+        properties: {
+          location: 'left',
+        },
+      },
+      shape: {},
+      type: 'torrents-status',
+      properties: {
+        labelFilter: [],
+        labelFilterIsWhitelist: false,
+        displayCompletedTorrents: false,
+        displayActiveTorrents: true,
+        speedLimitOfActiveTorrents: 10,
+        displayStaleTorrents: true,
+      },
+    };
+    const torrents: NormalizedTorrent[] = [
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
+      constructTorrent('HH', 'I am completed and uploading less than 10 ko/s (10239 ≈ 9.99ko/s)', true, 0, 10239),
+      constructTorrent('HH', 'I am completed and uploading more than 10 ko/s (10241 ≈ 10.01ko/s)', true, 0, 10241),
+      constructTorrent('HH', 'I am completed', true, 0, 0),
+      constructTorrent('HH', 'I am stale', false, 0, 0),
+    ];
+
+    // act
+    const filtered = filterTorrents(widget, torrents);
+
+    // assert
+    expect(filtered.length).toBe(3);
+    expect(filtered.at(0)).toBe(torrents[0]);
+    expect(filtered.includes(torrents[1])).toBe(false);
+    expect(filtered.at(1)).toBe(torrents[2]);
+    expect(filtered.includes(torrents[3])).toBe(false);
+    expect(filtered.at(2)).toBe(torrents[4]);
   });
 
   it('filter by label when whitelist', () => {
@@ -125,13 +172,15 @@ describe('TorrentTile', () => {
         labelFilter: ['music', 'movie'],
         labelFilterIsWhitelist: true,
         displayCompletedTorrents: true,
+        displayActiveTorrents: true,
+        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('1', 'A sick drop', false, 672, 'music'),
-      constructTorrent('2', 'I cried', true, 0, 'movie'),
-      constructTorrent('3', 'Great Animations', false, 0, 'anime'),
+      constructTorrent('1', 'A sick drop', false, 672, 672, 'music'),
+      constructTorrent('2', 'I cried', true, 0, 0, 'movie'),
+      constructTorrent('3', 'Great Animations', false, 0, 0, 'anime'),
     ];
 
     // act
@@ -160,13 +209,15 @@ describe('TorrentTile', () => {
         labelFilter: ['music', 'movie'],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: false,
+        displayActiveTorrents: false,
+        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 'anime'),
-      constructTorrent('HH', 'I am completed', true, 0, 'movie'),
-      constructTorrent('HH', 'I am stale', false, 0, 'tv'),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 672, 'anime'),
+      constructTorrent('HH', 'I am completed', true, 0, 0, 'movie'),
+      constructTorrent('HH', 'I am stale', false, 0, 0, 'tv'),
     ];
 
     // act
@@ -178,13 +229,53 @@ describe('TorrentTile', () => {
     expect(filtered.includes(torrents[1])).toBe(false);
     expect(filtered.at(1)).toBe(torrents[2]);
   });
+
+  it('calcul ratio with and without torrent', () => {
+    // arrange
+    const widget: ITorrent = {
+      id: 'abc',
+      area: {
+        type: 'sidebar',
+        properties: {
+          location: 'left',
+        },
+      },
+      shape: {},
+      type: 'torrents-status',
+      properties: {
+        labelFilter: [],
+        labelFilterIsWhitelist: false,
+        displayCompletedTorrents: false,
+        displayActiveTorrents: false,
+        speedLimitOfActiveTorrents: 10,
+        displayStaleTorrents: true,
+      },
+    };
+    const torrents: NormalizedTorrent[] = [
+      constructTorrent('HH', 'I am completed', true, 0, 672),
+    ];
+
+    // act
+    const filtered = filterTorrents(widget, torrents);
+    const ratioGlobal = getTorrentsRatio(widget, torrents, false);
+    const ratioWithFilter = getTorrentsRatio(widget, torrents, true);
+
+    // assert
+    expect(filtered.length).toBe(0);
+    expect(filtered.includes(torrents[1])).toBe(false);
+    expect(ratioGlobal).toBe(378535535/23024335);
+    expect(ratioWithFilter).toBe(-1); //infinite ratio
+	
+  });
+
 });
 
 const constructTorrent = (
   id: string,
   name: string,
   isCompleted: boolean,
-  downloadSpeed: number,
+  downloadSpeed: number, // Bytes per second in @ctrl/shared-torrent
+  uploadSpeed: number, // Bytes per second in @ctrl/shared-torrent
   label?: string
 ): NormalizedTorrent => ({
   id,
@@ -208,6 +299,6 @@ const constructTorrent = (
   totalSize: 839539535,
   totalSelected: 0,
   totalUploaded: 378535535,
-  uploadSpeed: 8349,
+  uploadSpeed,
   label,
 });

--- a/src/widgets/torrent/TorrentTile.spec.ts
+++ b/src/widgets/torrent/TorrentTile.spec.ts
@@ -20,15 +20,13 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: true,
-        displayActiveTorrents: true,
-        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: false,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
-      constructTorrent('HH', 'I am completed', true, 0, 0),
-      constructTorrent('HH', 'I am stale', false, 0, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672),
+      constructTorrent('HH', 'I am completed', true, 0),
+      constructTorrent('HH', 'I am stale', false, 0),
     ];
 
     // act
@@ -57,15 +55,13 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: true,
-        displayActiveTorrents: true,
-        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
-      constructTorrent('HH', 'I am completed', true, 0, 0),
-      constructTorrent('HH', 'I am stale', false, 0, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672),
+      constructTorrent('HH', 'I am completed', true, 0),
+      constructTorrent('HH', 'I am stale', false, 0),
     ];
 
     // act
@@ -78,7 +74,7 @@ describe('TorrentTile', () => {
     expect(filtered.includes(torrents[2])).toBe(true);
   });
 
-  it('filter when completed without active torrent', () => {
+  it('filter when completed', () => {
     // arrange
     const widget: ITorrent = {
       id: 'abc',
@@ -94,15 +90,13 @@ describe('TorrentTile', () => {
         labelFilter: [],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: false,
-        displayActiveTorrents: false,
-        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
-      constructTorrent('HH', 'I am completed', true, 0, 672),
-      constructTorrent('HH', 'I am stale', false, 0, 0),
+      constructTorrent('ABC', 'Nice Torrent', false, 672),
+      constructTorrent('HH', 'I am completed', true, 0),
+      constructTorrent('HH', 'I am stale', false, 0),
     ];
 
     // act
@@ -113,47 +107,6 @@ describe('TorrentTile', () => {
     expect(filtered.at(0)).toBe(torrents[0]);
     expect(filtered.includes(torrents[1])).toBe(false);
     expect(filtered.at(1)).toBe(torrents[2]);
-  });
-
-  it('filter when completed with active torrent', () => {
-    // arrange
-    const widget: ITorrent = {
-      id: 'abc',
-      area: {
-        type: 'sidebar',
-        properties: {
-          location: 'left',
-        },
-      },
-      shape: {},
-      type: 'torrents-status',
-      properties: {
-        labelFilter: [],
-        labelFilterIsWhitelist: false,
-        displayCompletedTorrents: false,
-        displayActiveTorrents: true,
-        speedLimitOfActiveTorrents: 10,
-        displayStaleTorrents: true,
-      },
-    };
-    const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 672),
-      constructTorrent('HH', 'I am completed and uploading less than 10 ko/s (10239 ≈ 9.99ko/s)', true, 0, 10239),
-      constructTorrent('HH', 'I am completed and uploading more than 10 ko/s (10241 ≈ 10.01ko/s)', true, 0, 10241),
-      constructTorrent('HH', 'I am completed', true, 0, 0),
-      constructTorrent('HH', 'I am stale', false, 0, 0),
-    ];
-
-    // act
-    const filtered = filterTorrents(widget, torrents);
-
-    // assert
-    expect(filtered.length).toBe(3);
-    expect(filtered.at(0)).toBe(torrents[0]);
-    expect(filtered.includes(torrents[1])).toBe(false);
-    expect(filtered.at(1)).toBe(torrents[2]);
-    expect(filtered.includes(torrents[3])).toBe(false);
-    expect(filtered.at(2)).toBe(torrents[4]);
   });
 
   it('filter by label when whitelist', () => {
@@ -172,15 +125,13 @@ describe('TorrentTile', () => {
         labelFilter: ['music', 'movie'],
         labelFilterIsWhitelist: true,
         displayCompletedTorrents: true,
-        displayActiveTorrents: true,
-        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('1', 'A sick drop', false, 672, 672, 'music'),
-      constructTorrent('2', 'I cried', true, 0, 0, 'movie'),
-      constructTorrent('3', 'Great Animations', false, 0, 0, 'anime'),
+      constructTorrent('1', 'A sick drop', false, 672, 'music'),
+      constructTorrent('2', 'I cried', true, 0, 'movie'),
+      constructTorrent('3', 'Great Animations', false, 0, 'anime'),
     ];
 
     // act
@@ -209,15 +160,13 @@ describe('TorrentTile', () => {
         labelFilter: ['music', 'movie'],
         labelFilterIsWhitelist: false,
         displayCompletedTorrents: false,
-        displayActiveTorrents: false,
-        speedLimitOfActiveTorrents: 10,
         displayStaleTorrents: true,
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('ABC', 'Nice Torrent', false, 672, 672, 'anime'),
-      constructTorrent('HH', 'I am completed', true, 0, 0, 'movie'),
-      constructTorrent('HH', 'I am stale', false, 0, 0, 'tv'),
+      constructTorrent('ABC', 'Nice Torrent', false, 672, 'anime'),
+      constructTorrent('HH', 'I am completed', true, 0, 'movie'),
+      constructTorrent('HH', 'I am stale', false, 0, 'tv'),
     ];
 
     // act
@@ -229,8 +178,8 @@ describe('TorrentTile', () => {
     expect(filtered.includes(torrents[1])).toBe(false);
     expect(filtered.at(1)).toBe(torrents[2]);
   });
-
-  it('calcul ratio with and without torrent', () => {
+  
+  it('calcul ratio', () => {
     // arrange
     const widget: ITorrent = {
       id: 'abc',
@@ -252,7 +201,7 @@ describe('TorrentTile', () => {
       },
     };
     const torrents: NormalizedTorrent[] = [
-      constructTorrent('HH', 'I am completed', true, 0, 672),
+      constructTorrent('HH', 'I am completed', true, 0),
     ];
 
     // act
@@ -265,17 +214,14 @@ describe('TorrentTile', () => {
     expect(filtered.includes(torrents[1])).toBe(false);
     expect(ratioGlobal).toBe(378535535/23024335);
     expect(ratioWithFilter).toBe(-1); //infinite ratio
-	
   });
-
 });
 
 const constructTorrent = (
   id: string,
   name: string,
   isCompleted: boolean,
-  downloadSpeed: number, // Bytes per second in @ctrl/shared-torrent
-  uploadSpeed: number, // Bytes per second in @ctrl/shared-torrent
+  downloadSpeed: number,
   label?: string
 ): NormalizedTorrent => ({
   id,
@@ -299,6 +245,6 @@ const constructTorrent = (
   totalSize: 839539535,
   totalSelected: 0,
   totalUploaded: 378535535,
-  uploadSpeed,
+  uploadSpeed: 8349,
   label,
 });

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -55,6 +55,7 @@ const definition = defineWidget({
     displayRatioWithFilter: {
       type: 'switch',
       defaultValue: true,
+      info: true,
     },
   },
   gridstack: {

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -247,18 +247,27 @@ const filterTorrentsByLabels = (
 export const getTorrentsRatio = (
   widget: ITorrent,
   torrents: NormalizedTorrent[],
-  applyAllFilter:boolean
+  applyAllFilter: boolean
 ) => {
-
-  if(applyAllFilter) {
-    torrents = filterTorrents(widget,torrents)
+  if (applyAllFilter) {
+    torrents = filterTorrents(widget, torrents);
   } else if (widget.properties.labelFilter.length > 0) {
-    torrents = filterTorrentsByLabels(torrents, widget.properties.labelFilter,widget.properties.labelFilterIsWhitelist)
+    torrents = filterTorrentsByLabels(
+      torrents,
+      widget.properties.labelFilter,
+      widget.properties.labelFilterIsWhitelist
+    );
   }
 
-  let totalDownloadedSum = torrents.reduce((sum, torrent) => sum + torrent.totalDownloaded, 0);
+  let totalDownloadedSum = torrents.reduce(
+    (sum, torrent) => sum + torrent.totalDownloaded,
+    0
+  );
 
-  return totalDownloadedSum > 0 ? torrents.reduce((sum, torrent) => sum + torrent.totalUploaded, 0) / totalDownloadedSum : -1;
-}
+  return totalDownloadedSum > 0
+    ? torrents.reduce((sum, torrent) => sum + torrent.totalUploaded, 0) /
+        totalDownloadedSum
+    : -1;
+};
 
 export default definition;

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -245,7 +245,7 @@ const getRatio = (
 
   if(applyAllFilter) {
     torrents = filterTorrents(widget,torrents)
-  } else {
+  } else if (widget.properties.labelFilter.length > 0) {
     torrents = filterTorrentsByLabels(torrents, widget.properties.labelFilter,widget.properties.labelFilterIsWhitelist)
   }
 

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -144,8 +144,8 @@ function TorrentTile({ widget }: TorrentTileProps) {
   const duration = dayjs.duration(difference, 'ms');
   const humanizedDuration = duration.humanize();
 
-  const ratioGlobal = getRatio(widget, torrents, false);
-  const ratioWithFilter = getRatio(widget, torrents, true);
+  const ratioGlobal = getTorrentsRatio(widget, torrents, false);
+  const ratioWithFilter = getTorrentsRatio(widget, torrents, true);
 
   return (
     <Flex direction="column" sx={{ height: '100%' }} ref={ref}>
@@ -237,7 +237,7 @@ const filterTorrentsByLabels = (
   return torrents.filter((torrent) => !labels.includes(torrent.label as string));
 };
 
-const getRatio = (
+const getTorrentsRatio = (
   widget: ITorrent,
   torrents: NormalizedTorrent[],
   applyAllFilter:boolean

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -237,7 +237,7 @@ const filterTorrentsByLabels = (
   return torrents.filter((torrent) => !labels.includes(torrent.label as string));
 };
 
-const getTorrentsRatio = (
+export const getTorrentsRatio = (
   widget: ITorrent,
   torrents: NormalizedTorrent[],
   applyAllFilter:boolean

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -191,7 +191,14 @@ function TorrentTile({ widget }: TorrentTileProps) {
         )}
 
         <Text color="dimmed" size="xs">
-        {t('card.footer.lastUpdated', { time: humanizedDuration })} - {t('card.footer.ratioGlobal')} : {ratioGlobal === -1 ? "∞" : ratioGlobal.toFixed(2)} {widget.properties.displayRatioWithFilter && ` - ${t('card.footer.ratioWithFilter')} : ${ratioWithFilter === -1 ? "∞" : ratioWithFilter.toFixed(2)}`}
+        {t('card.footer.lastUpdated', { time: humanizedDuration })}
+          {` - ${t('card.footer.ratioGlobal')} : ${
+            ratioGlobal === -1 ? '∞' : ratioGlobal.toFixed(2)
+          }`}
+          {widget.properties.displayRatioWithFilter &&
+            ` - ${t('card.footer.ratioWithFilter')} : ${
+              ratioWithFilter === -1 ? '∞' : ratioWithFilter.toFixed(2)
+            }`}
         </Text>
       </Group>
     </Flex>

--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -52,6 +52,10 @@ const definition = defineWidget({
       type: 'multiple-text',
       defaultValue: [] as string[],
     },
+    displayRatioWithFilter: {
+      type: 'switch',
+      defaultValue: true,
+    },
   },
   gridstack: {
     minWidth: 2,
@@ -140,6 +144,9 @@ function TorrentTile({ widget }: TorrentTileProps) {
   const duration = dayjs.duration(difference, 'ms');
   const humanizedDuration = duration.humanize();
 
+  const ratioGlobal = getRatio(widget, torrents, false);
+  const ratioWithFilter = getRatio(widget, torrents, true);
+
   return (
     <Flex direction="column" sx={{ height: '100%' }} ref={ref}>
       <ScrollArea sx={{ height: '100%', width: '100%' }} mb="xs">
@@ -184,7 +191,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
         )}
 
         <Text color="dimmed" size="xs">
-          {t('card.footer.lastUpdated', { time: humanizedDuration })}
+        {t('card.footer.lastUpdated', { time: humanizedDuration })} - {t('card.footer.ratioGlobal')} : {ratioGlobal === -1 ? "∞" : ratioGlobal.toFixed(2)} {widget.properties.displayRatioWithFilter && ` - ${t('card.footer.ratioWithFilter')} : ${ratioWithFilter === -1 ? "∞" : ratioWithFilter.toFixed(2)}`}
         </Text>
       </Group>
     </Flex>
@@ -229,5 +236,22 @@ const filterTorrentsByLabels = (
 
   return torrents.filter((torrent) => !labels.includes(torrent.label as string));
 };
+
+const getRatio = (
+  widget: ITorrent,
+  torrents: NormalizedTorrent[],
+  applyAllFilter:boolean
+) => {
+
+  if(applyAllFilter) {
+    torrents = filterTorrents(widget,torrents)
+  } else {
+    torrents = filterTorrentsByLabels(torrents, widget.properties.labelFilter,widget.properties.labelFilterIsWhitelist)
+  }
+
+  let totalDownloadedSum = torrents.reduce((sum, torrent) => sum + torrent.totalDownloaded, 0);
+
+  return totalDownloadedSum > 0 ? torrents.reduce((sum, torrent) => sum + torrent.totalUploaded, 0) / totalDownloadedSum : -1;
+}
 
 export default definition;


### PR DESCRIPTION
### Category
> Feature

### Overview
> Add global ratio and filtered torrents list ratio

### New Vars
> Var : widget.properties.displayRatioWithFilter & ratioGlobal & ratioWithFilter
> Function : getTorrentsRatio

### Screenshot
![image](https://github.com/ajnart/homarr/assets/10882916/f60eb896-8247-4f1b-9f7c-2cb5bc7939b1)

The global ratio is calculated using the labels if they are defined
The filtered torrent list ratio is calculated using only the displayed torrents and can be disabled in the widget settings.

