### PR TITLE
🔇 Remove unnecessary console logs

### DIFF
--- a/src/tools/config/getFrontendConfig.ts
+++ b/src/tools/config/getFrontendConfig.ts
@@ -41,8 +41,6 @@ export const getFrontendConfig = async (name: string): Promise<ConfigType> => {
     );
   }
 
-  Consola.info(`Requested frontend content of configuration '${name}'`);
-  // If not, return the config
   const someAppsWithoutProps = config.apps.filter(
     (app) =>
       app.integration?.properties.some(

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -42,7 +42,6 @@ const getTrpcConfiguration = () => ({
 const getBaseUrl = () => {
   if (typeof window !== 'undefined') return ''; // browser should use relative url
   if (env.HOSTNAME) {
-    console.log('Constructing internal hostname address using', env.HOSTNAME, env.NEXT_PUBLIC_PORT);
     return `http://${env.HOSTNAME}:${env.NEXT_PUBLIC_PORT}`;
   }
   return `http://localhost:${env.NEXT_PUBLIC_PORT ?? 3000}`; // dev SSR should use localhost


### PR DESCRIPTION
Remove the following
```
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
ℹ Requested frontend content of configuration 'default'
Constructing internal hostname address using 5515f208127d 7575
```
Because it doesn't really add any value