### PR TITLE
🐛 Logo has no height and object-fit is not contain #1581

### DIFF
--- a/src/components/layout/Common/Logo.tsx
+++ b/src/components/layout/Common/Logo.tsx
@@ -18,6 +18,12 @@ export function Logo({ size = 'md', withoutText = false }: LogoProps) {
     <Group spacing={size === 'md' ? 'xs' : 4} noWrap>
       <Image
         width={size === 'md' ? 50 : 12}
+        height={size === 'md' ? 50 : 12}
+        styles={{
+          image: {
+            objectFit: 'contain !important' as 'contain',
+          },
+        }}
         src={config?.settings.customization.logoImageUrl || '/imgs/logo/logo-color.svg'}
         alt="Homarr Logo"
         className="dashboard-header-logo-image"


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Added height to logo image, Added object fit of contain

### Issue Number
> Related issue: #1581
