### PR TITLE
🐛 Placeholder width stretches out of screen

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -42,7 +42,7 @@
 }
 
 .grid-stack>.grid-stack-item {
-  min-width: calc(percentage(1) * #{var(--gridstack-widget-width)});
+  min-width: #{var(--gridstack-widget-width)};
 }
 
 // Styling for sidebar grid-stack elements


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Adjust min-width of grid-stack-items

### Screenshot
![image](https://github.com/ajnart/homarr/assets/63781622/f945305f-c407-4c12-b90e-9135f1bddd0d)
