### PR TITLE
Corrected a typo in the Docker integration EN locale

### DIFF
--- a/public/locales/en/tools/docker.json
+++ b/public/locales/en/tools/docker.json
@@ -2,7 +2,7 @@
     "title": "Docker",
     "alerts": {
         "notConfigured": {
-            "text": "Your Homarr instance does not have Docker configured or it has falied to fetch containers. Please check the documentation on how to set up the integration."
+            "text": "Your Homarr instance does not have Docker configured or it has failed to fetch containers. Please check the documentation on how to set up the integration."
         }
     },
     "modals": {


### PR DESCRIPTION
### Category
Other: Typo Fix

### Overview
Found a simple typo in the English locale for the Docker integration and fixed it.
