### PR TITLE
:adhesive_bandage: "," after the last language item in the about page

### DIFF
--- a/src/components/layout/header/About/Translators.tsx
+++ b/src/components/layout/header/About/Translators.tsx
@@ -74,8 +74,8 @@ export function TranslatorsTable({ loadedLanguages }: { loadedLanguages: number 
           }}
         >
           <Text lineClamp={1}>
-            {translator.languages.map((language) => (
-              <span key={language.id}>{language.name}, </span>
+            {translator.languages.map((language, index) => (
+              <span key={language.id}>{language.name}{(index < translator.languages.length - 1 ? ", " : "")}</span>
             ))}
           </Text>
         </td>


### PR DESCRIPTION
### Category
Bugfix

### Overview
I fixed a bug that displayed a ```,``` after the last item at ```/manage/about```. I haven't worked with React before, so it could be that there is a better solution but thats my way how I would solve this problem :)

### Screenshot of the problem
![image](https://github.com/ajnart/homarr/assets/47495914/5950886b-eac7-4a87-ba54-c7733767de03)

