### PR TITLE
Header logo size fix

### DIFF
--- a/src/components/layout/Common/Logo.tsx
+++ b/src/components/layout/Common/Logo.tsx
@@ -17,8 +17,8 @@ export function Logo({ size = 'md', withoutText = false }: LogoProps) {
   return (
     <Group spacing={size === 'md' ? 'xs' : 4} noWrap>
       <Image
-        width={size === 'md' ? 50 : 12}
-        height={size === 'md' ? 50 : 12}
+        width="unset"
+        height={size === 'md' ? 38 : 12}
         styles={{
           image: {
             objectFit: 'contain !important' as 'contain',


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Based on @Meierschlumpf changes in #1584, ironing the kink out.
> Unsetting width so only height would matter (Just removing the width wouldn't work as it has a default value to 100%, needs to actively be unset).
> Forcing height to a set value to fit in the header (in this case, just changed to 38 since 50 was too big. Header is 60px, margin top of 10 and padding bottom of 12.)

### Issue Number
> Related issue: #1581
