### PR TITLE
🐛 Remove ability to modify text to non admins

### DIFF
--- a/src/widgets/notebook/NotebookEditor.tsx
+++ b/src/widgets/notebook/NotebookEditor.tsx
@@ -49,9 +49,9 @@ import TextStyle from '@tiptap/extension-text-style';
 import Underline from '@tiptap/extension-underline';
 import { BubbleMenu, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
+import { useSession } from 'next-auth/react';
 import { useTranslation } from 'next-i18next';
 import { Dispatch, SetStateAction, useState } from 'react';
-import { useEditModeStore } from '~/components/Dashboard/Views/useEditModeStore';
 import { useConfigContext } from '~/config/provider';
 import { useConfigStore } from '~/config/store';
 import { api } from '~/utils/api';
@@ -63,7 +63,8 @@ export function Editor({ widget }: { widget: INotebookWidget }) {
   const [content, setContent] = useState(widget.properties.content);
   const [toSaveContent, setToSaveContent] = useState(content);
 
-  const { enabled } = useEditModeStore();
+  const { data: sessionData } = useSession();
+  const enabled = !!sessionData?.user.isAdmin;
   const [isEditing, setIsEditing] = useState(false);
 
   const { config, name: configName } = useConfigContext();
@@ -327,7 +328,7 @@ export function Editor({ widget }: { widget: INotebookWidget }) {
           <RichTextEditor.Content />
         </ScrollArea>
       </RichTextEditor>
-      {!enabled && (
+      {enabled && (
         <>
           <ActionIcon
             title={isEditing ? t('common:save') : t('common:edit')}

--- a/src/widgets/notebook/NotebookEditor.tsx
+++ b/src/widgets/notebook/NotebookEditor.tsx
@@ -120,11 +120,12 @@ export function Editor({ widget }: { widget: INotebookWidget }) {
         TaskItem.configure({
           nested: true,
           onReadOnlyChecked: (node, checked) => {
-            if (widget.properties.allowReadOnlyCheck) {
+            if (widget.properties.allowReadOnlyCheck && enabled) {
               const event = new CustomEvent('onReadOnlyCheck', { detail: { node, checked } });
               dispatchEvent(event);
+              return true;
             }
-            return widget.properties.allowReadOnlyCheck;
+            return false;
           },
         }),
         TaskList.configure({ itemTypeName: 'taskItem' }),


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Although non savable, non admin users could go into edit mode.
> Also made ticks unresponsive to non admins as it's supposed to save to config and only admins can do that. (to revisit once the config system changes in the future)

### Issue Number _(if applicable)_
> closes: #1632
