### PR TITLE
🐛 Error object not compatible with json parsing of gssp

### DIFF
--- a/src/components/Onboarding/database-not-writeable.tsx
+++ b/src/components/Onboarding/database-not-writeable.tsx
@@ -1,7 +1,13 @@
 import { Center, Code, List, Stack, Text, Title } from '@mantine/core';
 import Head from 'next/head';
 
-export const DatabaseNotWriteable = ({ error, errorMessage }: { error: any | unknown, errorMessage: string | undefined }) => {
+export const DatabaseNotWriteable = ({
+  stringifiedError,
+  errorMessage,
+}: {
+  stringifiedError: string | undefined;
+  errorMessage: string | undefined;
+}) => {
   return (
     <>
       <Head>
@@ -30,11 +36,9 @@ export const DatabaseNotWriteable = ({ error, errorMessage }: { error: any | unk
               </a>
             </List.Item>
           </List>
-          <Code block>{error && JSON.stringify(error)}</Code>
+          <Code block>{stringifiedError}</Code>
 
-          {errorMessage && (
-            <Code block>{errorMessage}</Code>
-          )}
+          {errorMessage && <Code block>{errorMessage}</Code>}
         </Stack>
       </Center>
     </>

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -124,7 +124,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     }
     Consola.info('Database is writeable');
 
-    if (process.platform !== 'win32') {
+    if (process.platform !== 'win32' || env.NEXT_PUBLIC_NODE_ENV === 'development') {
       try {
         const { stdout, stderr } = await exec("mount | grep '/data'");
 

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -15,9 +15,6 @@ import { getTotalUserCountAsync } from '~/server/db/queries/user';
 import { getConfig } from '~/tools/config/getConfig';
 import { getServerSideTranslations } from '~/tools/server/getServerSideTranslations';
 
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
-
 export default function OnboardPage({
   configSchemaVersions,
   databaseNotWriteable,

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -21,8 +21,8 @@ const exec = util.promisify(require('child_process').exec);
 export default function OnboardPage({
   configSchemaVersions,
   databaseNotWriteable,
-  error,
-  errorMessage
+  stringifiedError,
+  errorMessage,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { fn, colors, colorScheme } = useMantineTheme();
   const background = colorScheme === 'dark' ? 'dark.6' : 'gray.1';
@@ -49,7 +49,7 @@ export default function OnboardPage({
         </Center>
 
         {databaseNotWriteable == true ? (
-          <DatabaseNotWriteable error={error} errorMessage={errorMessage} />
+          <DatabaseNotWriteable stringifiedError={stringifiedError} errorMessage={errorMessage} />
         ) : (
           <>
             {onboardingSteps ? (
@@ -117,7 +117,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
           ...translations,
           configSchemaVersions: configSchemaVersions,
           databaseNotWriteable: true,
-          error: error,
+          errorMessage: 'Database is not writeable',
+          stringifiedError: JSON.stringify(error),
         },
       };
     }
@@ -128,13 +129,18 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
         const { stdout, stderr } = await exec("mount | grep '/data'");
 
         if (stderr.split('\n').length > 1 || stdout.split('\n').length <= 1) {
-          Consola.error(`Database at '${rawDatabaseUrl}' has not been mounted: ${stdout.replace('\n', '\\n')} ${stderr.replace('\n', '\\n')}`);
+          Consola.error(
+            `Database at '${rawDatabaseUrl}' has not been mounted: ${stdout.replace(
+              '\n',
+              '\\n'
+            )} ${stderr.replace('\n', '\\n')}`
+          );
           return {
             props: {
               ...translations,
               configSchemaVersions: configSchemaVersions,
               databaseNotWriteable: true,
-              error: `Database at '${rawDatabaseUrl}' is not mounted:\n${stdout}`,
+              errorMessage: `Database at '${rawDatabaseUrl}' is not mounted:\n${stdout}`,
             },
           };
         }
@@ -146,8 +152,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
             ...translations,
             configSchemaVersions: configSchemaVersions,
             databaseNotWriteable: true,
-            error: error,
-            errorMessage: errorMessage
+            stringifiedError: JSON.stringify(error),
+            errorMessage: errorMessage,
           },
         };
       }
@@ -160,7 +166,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     props: {
       ...translations,
       configSchemaVersions: configSchemaVersions,
-      databaseNotWriteable: false
+      databaseNotWriteable: false,
     },
   };
 };

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -122,42 +122,6 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
         },
       };
     }
-    Consola.info('Database is writeable');
-
-    if (process.platform !== 'win32' && env.NEXT_PUBLIC_NODE_ENV === 'production') {
-      try {
-        const { stdout, stderr } = await exec("mount | grep '/data'");
-
-        if (stderr.split('\n').length > 1 || stdout.split('\n').length <= 1) {
-          Consola.error(
-            `Database at '${rawDatabaseUrl}' has not been mounted: ${stdout.replace(
-              '\n',
-              '\\n'
-            )} ${stderr.replace('\n', '\\n')}`
-          );
-          return {
-            props: {
-              ...translations,
-              configSchemaVersions: configSchemaVersions,
-              databaseNotWriteable: true,
-              errorMessage: `Database at '${rawDatabaseUrl}' is not mounted:\n${stdout}`,
-            },
-          };
-        }
-      } catch (error) {
-        const errorMessage = `Database at '${rawDatabaseUrl}' has not been mounted: ${error}`;
-        Consola.error(errorMessage);
-        return {
-          props: {
-            ...translations,
-            configSchemaVersions: configSchemaVersions,
-            databaseNotWriteable: true,
-            stringifiedError: JSON.stringify(error),
-            errorMessage: errorMessage,
-          },
-        };
-      }
-    }
 
     Consola.info(`Database at '${rawDatabaseUrl}' is writeable and mounted`);
   }

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -124,7 +124,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     }
     Consola.info('Database is writeable');
 
-    if (process.platform !== 'win32' || env.NEXT_PUBLIC_NODE_ENV === 'development') {
+    if (process.platform !== 'win32' && env.NEXT_PUBLIC_NODE_ENV === 'production') {
       try {
         const { stdout, stderr } = await exec("mount | grep '/data'");
 


### PR DESCRIPTION
Fixing the following error:
```
ℹ Instance is using a database on the file system. Checking if file './data/db.sqlite' is writable...
ℹ Database is writeable

 ERROR  Database at './data/db.sqlite' has not been mounted: Error: Command failed: mount | grep '/data'


- error Error: Error serializing `.error` returned from `getServerSideProps` in "/onboard".
Reason: `object` ("[object Error]") cannot be serialized as JSON. Please only return JSON serializable data types.
```