### PR TITLE
🐛 Migrate package.json has no license field

### DIFF
--- a/drizzle/migrate/package.json
+++ b/drizzle/migrate/package.json
@@ -1,4 +1,5 @@
 {
+    "license": "MIT",
     "description": "This package.json is used for the migration script the dependencies are only installed within the Dockerfile.",
     "scripts": {
         "db:migrate": "ts-node ./migrate.ts"


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Add MIT-License to migrate package.json

### Issue Number
> Related issue: #1624