### PR TITLE
Update GeneralTab.tsx

### DIFF
--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/GeneralTab/GeneralTab.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/GeneralTab/GeneralTab.tsx
@@ -24,7 +24,6 @@ export const GeneralTab = ({ form, openTab }: GeneralTabProps) => {
     t('general.internalAddress.troubleshoot.lines.enablePings'),
     t('general.internalAddress.troubleshoot.lines.wget'),
     t('general.internalAddress.troubleshoot.lines.iframe'),
-    t('general.internalAddress.troubleshoot.lines.clearCache'),
   ];
 
   return (


### PR DESCRIPTION
### Category
> One of: Other Legacy troubleshooting information

### Overview
> Clearing the cache is no long required/available; and therefor should be removed from the troubleshooting tab. 

### Issue Number _(if applicable)_
> NIL, from discord comment: https://discord.com/channels/972958686051962910/972958689155764326/1174219683864522782

### New Vars _(if applicable)_
> No new variables, but I'm not actually sure where troubleshooting is stored' it should be cleaned as well.

### Alternative
> If local caching will return in the future, just comment out the line temporary.