### PR TITLE
🐛 Improve admin security over dnshole controls

### DIFF
--- a/public/locales/en/modules/dns-hole-controls.json
+++ b/public/locales/en/modules/dns-hole-controls.json
@@ -6,6 +6,9 @@
       "title": "DNS hole controls settings",
       "showToggleAllButtons": {
         "label": "Show 'Enable/Disable All' Buttons"
+      },
+      "allowUserControl": {
+        "label": "Allow normal users to use the toggle buttons"
       }
     },
     "errors": {

--- a/public/locales/en/modules/dns-hole-controls.json
+++ b/public/locales/en/modules/dns-hole-controls.json
@@ -6,9 +6,6 @@
       "title": "DNS hole controls settings",
       "showToggleAllButtons": {
         "label": "Show 'Enable/Disable All' Buttons"
-      },
-      "allowUserControl": {
-        "label": "Allow normal users to use the toggle buttons"
       }
     },
     "errors": {

--- a/src/server/api/routers/dns-hole/router.ts
+++ b/src/server/api/routers/dns-hole/router.ts
@@ -7,26 +7,19 @@ import { PiHoleClient } from '~/tools/server/sdk/pihole/piHole';
 import { ConfigAppType } from '~/types/app';
 import { AdStatistics } from '~/widgets/dnshole/type';
 
-import { createTRPCRouter, publicProcedure } from '../../trpc';
-import { TRPCError } from '@trpc/server';
+import { adminProcedure, createTRPCRouter, publicProcedure } from '../../trpc';
 
 export const dnsHoleRouter = createTRPCRouter({
-  control: publicProcedure
+  control: adminProcedure
     .input(
       z.object({
         action: z.enum(['enable', 'disable']),
         configName: z.string(),
-        widgetId: z.string(),
         appsToChange: z.optional(z.array(z.string())),
       })
     )
-    .mutation(async ({ input, ctx }) => {
+    .mutation(async ({ input }) => {
       const config = getConfig(input.configName);
-      const widget = config.widgets.find(({ id }) => input.widgetId === id)
-
-      if (widget !== undefined && widget.properties.allowUserControl ? ctx.session === null : !ctx.session?.user.isAdmin) {
-        throw new TRPCError({ code: 'UNAUTHORIZED' })
-      }
 
       const applicableApps = config.apps.filter(
         (app) =>


### PR DESCRIPTION
### Category
> Bugfix / Security

### Overview
> 1. Although DNS toggle all controls where hidden, the per item badge was still active.
> 2. Toggle function was not safe from CSS manipulation to regain access to it, made the toggle function only answer to admin users.
> 3. Non admins didn't have controls elements centered.

> Change allow controls to server side.
> Added ability to enable controls for non admins (But still users at least) with widget option.

### Issue Number
> Reported in #1685
