### PR TITLE
🐛 affix overlapping custom CSS box

### DIFF
--- a/src/pages/board/[slug]/customize.tsx
+++ b/src/pages/board/[slug]/customize.tsx
@@ -229,7 +229,7 @@ export default function CustomizationPage({
           )}
         </Transition>
       </Affix>
-      <Container>
+      <Container pb="6rem">
         <Paper p="xl" py="sm" mih="100%" withBorder>
           <Stack>
             <Group position="apart">


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Save changes affix would overlap the bottom of the custom CSS box, making it impossible to read new lines when writing them

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/10859f4a-c0f7-4947-8ede-7540855f7f14)
