### PR TITLE
Updated entityStateSchema to handle nullables

### DIFF
--- a/src/tools/server/sdk/homeassistant/models/EntityState.ts
+++ b/src/tools/server/sdk/homeassistant/models/EntityState.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 
 export const entityStateSchema = z.object({
-  attributes: z.record(z.union([z.string(), z.number(), z.boolean()])),
+  attributes: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])),
   entity_id: z.string(),
   last_changed: z.string().pipe(z.coerce.date()),
   last_updated: z.string().pipe(z.coerce.date()),


### PR DESCRIPTION
### Category
> Feature 

### Overview
> I've added a new possible data type, that can come from HA. This is a problem as many objects have empty attributes, such as TrueNAS integration.
```
{
    "attributes": {
        "state_class": "measurement",
        "attribution": "Data provided by TrueNAS integration",
        "Path": "/",
        "Status": "ONLINE",
        "Healthy": true,
        "Is decrypted": true,
        "Autotrim": false,
        "Scrub state": "FINISHED",
        "Scrub start": "1970-01-01T00:00:00+00:00",
        "Scrub end": "1970-01-01T00:00:00+00:00",
        "Scrub secs left": null,
        "Total GiB": 0,
        "unit_of_measurement": "GiB",
        "icon": "mdi:database-settings",
        "friendly_name": "pool free"
    },
    "entity_id": "sensor.some_entity_id",
    "last_changed": "1970-01-01T00:00:00.000Z",
    "last_updated": "1970-01-01T00:00:00.000Z",
    "state": "999.99"
}
```

