### PR TITLE
🔧 Configure Stale Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '18 17 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'Stale'
+        stale-pr-label: 'Stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,8 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
+        stale-issue-message: "Hello 👋, this issue has been open for 60 without activity. Please close this issue if it's no longer relevant or has been resolved. Still relevant? Simply reply and I'll mark it as active."
+        stale-pr-message: 'Hello 👋, this PR has gone stale. Please reply to mark it as active.'
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
+        days-before-close: -1


### PR DESCRIPTION
By default 60 days until an issue or PR is marked as stale.
After that, 7 days until closure:
https://github.com/actions/stale

https://github.com/actions/stale#list-of-input-options