### PR TITLE
:bug: Nan for size in torrent widget

### DIFF
--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -162,7 +162,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
       ),
     },
     {
-      accessorKey: 'totalSize',
+      accessorKey: 'totalSelected',
       header: t('card.table.header.size'),
       Cell: ({ cell }) => formatSize(Number(cell.getValue())),
       sortDescFirst: true,


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> https://github.com/ajnart/homarr/pull/1557 made some changes to the torrent widget. The widget used to use total selected for size but with the change it looks like it was accidentally changed to total size. Total size doesn't seem to return anything (at least not for deluge) and additionally it makes more sense to use total_selected as this is the size of the files that are actually being downloaded instead of the size of the torrent. 

### Issue Number _(if applicable)_
> Related issue: #1781
