### PR TITLE
Add availability information about media requests

### DIFF
--- a/public/locales/en/modules/media-requests-list.json
+++ b/public/locales/en/modules/media-requests-list.json
@@ -16,7 +16,9 @@
   "state": {
     "approved": "Approved",
     "pendingApproval": "Pending approval",
-    "declined": "Declined"
+    "declined": "Declined",
+    "available": "Available",
+    "partial": "Partial"
   },
   "tooltips": {
     "approve": "Approve requests",

--- a/src/server/api/routers/media-request.ts
+++ b/src/server/api/routers/media-request.ts
@@ -62,7 +62,7 @@ export const mediaRequestsRouter = createTRPCRouter({
                   userRequestCount: item.requestedBy.requestCount,
                   airDate: genericItem.airDate,
                   status: item.status,
-                  availability: item.media.status,
+                  availability: item.is4k ? item.media.status4k : item.media.status,
                   backdropPath: `https://image.tmdb.org/t/p/original/${genericItem.backdropPath}`,
                   posterPath: `https://image.tmdb.org/t/p/w600_and_h900_bestv2/${genericItem.posterPath}`,
                   href: `${appUrl}/${item.type}/${item.media.tmdbId}`,

--- a/src/server/api/routers/media-request.ts
+++ b/src/server/api/routers/media-request.ts
@@ -62,6 +62,7 @@ export const mediaRequestsRouter = createTRPCRouter({
                   userRequestCount: item.requestedBy.requestCount,
                   airDate: genericItem.airDate,
                   status: item.status,
+                  availability: item.media.status,
                   backdropPath: `https://image.tmdb.org/t/p/original/${genericItem.backdropPath}`,
                   posterPath: `https://image.tmdb.org/t/p/w600_and_h900_bestv2/${genericItem.posterPath}`,
                   href: `${appUrl}/${item.type}/${item.media.tmdbId}`,
@@ -215,6 +216,7 @@ type OverseerrResponseItem = {
   status: number;
   createdAt: string;
   type: 'movie' | 'tv';
+  is4k: boolean;
   rootFolder: string;
   requestedBy: OverseerrResponseItemUser;
   media: OverseerrResponseItemMedia;
@@ -222,6 +224,8 @@ type OverseerrResponseItem = {
 
 type OverseerrResponseItemMedia = {
   tmdbId: number;
+  status: number;
+  status4k: number;
 };
 
 type OverseerrResponseItemUser = {

--- a/src/widgets/media-requests/MediaRequestListTile.tsx
+++ b/src/widgets/media-requests/MediaRequestListTile.tsx
@@ -24,7 +24,7 @@ import { defineWidget } from '../helper';
 import { WidgetLoading } from '../loading';
 import { IWidget } from '../widgets';
 import { useMediaRequestQuery } from './media-request-query';
-import { MediaRequest, MediaRequestStatus } from './media-request-types';
+import { MediaRequest, MediaRequestAvailability, MediaRequestStatus } from './media-request-types';
 
 const definition = defineWidget({
   id: 'media-requests-list',
@@ -154,7 +154,10 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
                 <Stack spacing={0}>
                   <Group spacing="xs">
                     {item.airDate && <Text>{item.airDate.split('-')[0]}</Text>}
-                    <MediaRequestStatusBadge status={item.status} />
+                    <MediaRequestStatusBadge
+                      status={item.status}
+                      availability={item.availability}
+                    />
                   </Group>
                   <Anchor
                     href={item.href}
@@ -245,11 +248,24 @@ function MediaRequestListTile({ widget }: MediaRequestListWidgetProps) {
   );
 }
 
-const MediaRequestStatusBadge = ({ status }: { status: MediaRequestStatus }) => {
+const MediaRequestStatusBadge = ({
+  status,
+  availability,
+}: {
+  status: MediaRequestStatus;
+  availability: MediaRequestAvailability;
+}) => {
   const { t } = useTranslation('modules/media-requests-list');
   switch (status) {
     case MediaRequestStatus.Approved:
-      return <Badge color="green">{t('state.approved')}</Badge>;
+      switch (availability) {
+        case MediaRequestAvailability.Available:
+          return <Badge color="green">{t('state.available')}</Badge>;
+        case MediaRequestAvailability.Partial:
+          return <Badge color="yellow">{t('state.partial')}</Badge>;
+        default:
+          return <Badge color="violet">{t('state.approved')}</Badge>;
+      }
     case MediaRequestStatus.Declined:
       return <Badge color="red">{t('state.declined')}</Badge>;
     case MediaRequestStatus.PendingApproval:

--- a/src/widgets/media-requests/media-request-types.tsx
+++ b/src/widgets/media-requests/media-request-types.tsx
@@ -11,6 +11,7 @@ export type MediaRequest = {
   userRequestCount: number;
   airDate?: string;
   status: MediaRequestStatus;
+  availability: MediaRequestAvailability;
   backdropPath: string;
   posterPath: string;
   href: string;
@@ -29,4 +30,12 @@ export enum MediaRequestStatus {
   PendingApproval = 1,
   Approved = 2,
   Declined = 3,
+}
+
+export enum MediaRequestAvailability {
+  Unknown = 1,
+  Pending = 2,
+  Processing = 3,
+  Partial = 4,
+  Available = 5,
 }


### PR DESCRIPTION
### Category
> Feature

> Added more detailed badges to the media request widget that specify if a request is available or partially available.

### Issue Number _(if applicable)_
> Related issue:  #1793

### Screenshot _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot.

![image](https://github.com/ajnart/homarr/assets/11760749/1bd64ba4-4ba4-45f5-8539-7c69bb964694)
![image](https://github.com/ajnart/homarr/assets/11760749/81e420c3-0818-46f3-b801-5b462caed555)
![image](https://github.com/ajnart/homarr/assets/11760749/610e8bad-487f-4622-a04f-f67bc62e7b86)
