### PR TITLE
Updated EntityStateSchema for homeassitant

### DIFF
--- a/src/tools/server/sdk/homeassistant/models/EntityState.ts
+++ b/src/tools/server/sdk/homeassistant/models/EntityState.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 
 export const entityStateSchema = z.object({
-  attributes: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])),
+  attributes: z.record(z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.union([z.string(),z.number()]))])),
   entity_id: z.string(),
   last_changed: z.string().pipe(z.coerce.date()),
   last_updated: z.string().pipe(z.coerce.date()),


### PR DESCRIPTION
Entities with more complex attributes was not supported with the old schema. A light with support for colors have arrays with modes and colors that caused a crash while fetching the entity. This change add support for that sort of entity.

### Category
Bugfix

### Overview
Expanded the entity state model to handle more complex entities.

When adding more complex entities such as lights with color support you get an error. The card shows the red exclamation mark and in the back-end you receive tRPC error about not being able to handle the entity state.

```shell
 ERROR  ❌ tRPC failed on smartHomeEntityState.retrieveStatus: Unable to handle Home Assistant entity state. This may be due to malformed response or unknown entity type. Check log for details
```

### Issue Number _(if applicable)_
 [Home Assistant Integration] Both type light and type switch don’t work, type sun is fine #1717 
