### PR TITLE
🐛 Notebook link target bug fix

### DIFF
--- a/src/widgets/notebook/NotebookEditor.tsx
+++ b/src/widgets/notebook/NotebookEditor.tsx
@@ -95,6 +95,13 @@ export function Editor({ widget }: { widget: INotebookWidget }) {
           validate(url) {
             return /^https?:\/\//.test(url);
           },
+        }).extend({
+          addAttributes() {
+            return {
+              ...this.parent?.(),
+              target: { default: null }
+            }
+          }
         }),
         StarterKit,
         Table.configure({


### PR DESCRIPTION
### Category
> One of: Bugfix

### Overview
> Notebook links always opened in new tab after saving.
> Simply add "target" as a saved attribute.

### Issue Number
> Discord report