### PR TITLE
feat: add environment variable to overwrite oidc scopes

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -1,13 +1,14 @@
 const { z } = require('zod');
 const { createEnv } = require('@t3-oss/env-nextjs');
 
-const trueStrings = ["1", "t", "T", "TRUE", "true", "True"];
-const falseStrings = ["0", "f", "F", "FALSE", "false", "False"];
+const trueStrings = ['1', 't', 'T', 'TRUE', 'true', 'True'];
+const falseStrings = ['0', 'f', 'F', 'FALSE', 'false', 'False'];
 
-const zodParsedBoolean = () => z
-  .enum([...trueStrings, ...falseStrings])
-  .default("false")
-  .transform((value) => trueStrings.includes(value))
+const zodParsedBoolean = () =>
+  z
+    .enum([...trueStrings, ...falseStrings])
+    .default('false')
+    .transform((value) => trueStrings.includes(value));
 
 const portSchema = z
   .string()
@@ -40,34 +41,38 @@ const env = createEnv({
     HOSTNAME: z.string().optional(),
 
     // Authentication
-    AUTH_PROVIDER: z.string().default('credentials').transform(providers => providers.replaceAll(' ', '').split(',')),
+    AUTH_PROVIDER: z
+      .string()
+      .default('credentials')
+      .transform((providers) => providers.replaceAll(' ', '').split(',')),
     // LDAP
     ...(authProviders.includes('ldap')
       ? {
-        AUTH_LDAP_URI: z.string().url(),
-        AUTH_LDAP_BIND_DN: z.string(),
-        AUTH_LDAP_BIND_PASSWORD: z.string(),
-        AUTH_LDAP_BASE: z.string(),
-        AUTH_LDAP_USERNAME_ATTRIBUTE: z.string().default('uid'),
-        AUTH_LDAP_GROUP_CLASS: z.string().default('groupOfUniqueNames'),
-        AUTH_LDAP_GROUP_MEMBER_ATTRIBUTE: z.string().default('member'),
-        AUTH_LDAP_GROUP_MEMBER_USER_ATTRIBUTE: z.string().default('dn'),
-        AUTH_LDAP_ADMIN_GROUP: z.string().default('admin'),
-        AUTH_LDAP_OWNER_GROUP: z.string().default('admin'),
-      }
+          AUTH_LDAP_URI: z.string().url(),
+          AUTH_LDAP_BIND_DN: z.string(),
+          AUTH_LDAP_BIND_PASSWORD: z.string(),
+          AUTH_LDAP_BASE: z.string(),
+          AUTH_LDAP_USERNAME_ATTRIBUTE: z.string().default('uid'),
+          AUTH_LDAP_GROUP_CLASS: z.string().default('groupOfUniqueNames'),
+          AUTH_LDAP_GROUP_MEMBER_ATTRIBUTE: z.string().default('member'),
+          AUTH_LDAP_GROUP_MEMBER_USER_ATTRIBUTE: z.string().default('dn'),
+          AUTH_LDAP_ADMIN_GROUP: z.string().default('admin'),
+          AUTH_LDAP_OWNER_GROUP: z.string().default('admin'),
+        }
       : {}),
     // OIDC
     ...(authProviders.includes('oidc')
       ? {
-        AUTH_OIDC_CLIENT_ID: z.string(),
-        AUTH_OIDC_CLIENT_SECRET: z.string(),
-        AUTH_OIDC_URI: z.string().url(),
-        // Custom Display name, defaults to OIDC
-        AUTH_OIDC_CLIENT_NAME: z.string().default('OIDC'),
-        AUTH_OIDC_ADMIN_GROUP: z.string().default('admin'),
-        AUTH_OIDC_OWNER_GROUP: z.string().default('admin'),
-        AUTH_OIDC_AUTO_LOGIN: zodParsedBoolean()
-      }
+          AUTH_OIDC_CLIENT_ID: z.string(),
+          AUTH_OIDC_CLIENT_SECRET: z.string(),
+          AUTH_OIDC_URI: z.string().url(),
+          // Custom Display name, defaults to OIDC
+          AUTH_OIDC_CLIENT_NAME: z.string().default('OIDC'),
+          AUTH_OIDC_ADMIN_GROUP: z.string().default('admin'),
+          AUTH_OIDC_OWNER_GROUP: z.string().default('admin'),
+          AUTH_OIDC_AUTO_LOGIN: zodParsedBoolean(),
+          AUTH_OIDC_SCOPE_OVERWRITE: z.string().default('openid email profile groups'),
+        }
       : {}),
   },
 
@@ -124,6 +129,7 @@ const env = createEnv({
     AUTH_OIDC_ADMIN_GROUP: process.env.AUTH_OIDC_ADMIN_GROUP,
     AUTH_OIDC_OWNER_GROUP: process.env.AUTH_OIDC_OWNER_GROUP,
     AUTH_OIDC_AUTO_LOGIN: process.env.AUTH_OIDC_AUTO_LOGIN,
+    AUTH_OIDC_SCOPE_OVERWRITE: process.env.AUTH_OIDC_SCOPE_OVERWRITE,
     DEMO_MODE: process.env.DEMO_MODE,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,

--- a/src/utils/auth/oidc.ts
+++ b/src/utils/auth/oidc.ts
@@ -20,13 +20,17 @@ const provider: OAuthConfig<Profile> = {
   clientId: env.AUTH_OIDC_CLIENT_ID,
   clientSecret: env.AUTH_OIDC_CLIENT_SECRET,
   wellKnown: `${env.AUTH_OIDC_URI}/.well-known/openid-configuration`,
-  authorization: { params: { scope: 'openid email profile groups' } },
+  authorization: { params: { scope: env.AUTH_OIDC_SCOPE_OVERWRITE } },
   idToken: true,
   async profile(profile) {
     const user = await adapter.getUserByEmail!(profile.email);
 
-    const isAdmin = profile.groups.includes(env.AUTH_OIDC_ADMIN_GROUP);
-    const isOwner = profile.groups.includes(env.AUTH_OIDC_OWNER_GROUP);
+    if (!profile.groups) {
+      Consola.warn('no groups found in profile of oidc user');
+    }
+
+    const isAdmin = profile.groups?.includes(env.AUTH_OIDC_ADMIN_GROUP);
+    const isOwner = profile.groups?.includes(env.AUTH_OIDC_OWNER_GROUP);
 
     // check for role update
     if (user && (user.isAdmin != isAdmin || user.isOwner != isOwner)) {

--- a/src/utils/auth/oidc.ts
+++ b/src/utils/auth/oidc.ts
@@ -25,7 +25,7 @@ const provider: OAuthConfig<Profile> = {
   async profile(profile) {
     const user = await adapter.getUserByEmail!(profile.email);
 
-    if (!profile.groups) {
+    if (profile.groups == undefined) {
       Consola.warn('no groups found in profile of oidc user');
     }
 


### PR DESCRIPTION
This new environment variable should allow to configure custom oidc scopes. This is for example useful for oidc with azure ad where the groups scope does not exist and groups are handled in another way