### PR TITLE
feat: Mention Emby on Jellyfin integration

### DIFF
--- a/src/components/Dashboard/Modals/EditAppModal/Tabs/IntegrationTab/Components/InputElements/IntegrationSelector.tsx
+++ b/src/components/Dashboard/Modals/EditAppModal/Tabs/IntegrationTab/Components/InputElements/IntegrationSelector.tsx
@@ -171,7 +171,7 @@ export const availableIntegrations = [
   {
     value: 'jellyfin',
     image: 'https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons@master/png/jellyfin.png',
-    label: 'Jellyfin',
+    label: 'Jellyfin (and Emby)',
   },
   {
     value: 'plex',


### PR DESCRIPTION
### Category
> Feature

### Overview
> Since Emby still uses the same API for our use, and as long as neither stray from their common API points, I have simply added the mention for Emby in the title of the integration for Jellyfin as they are, to a certain extent, the same.
> This is followed by a PR to mention it in the docs, underlying the statement before. https://github.com/homarr-labs/documentation/pull/41

> Please note, This is not a PR to "Add Emby", as this one is already, technically, in. There's is no reason to spend more time on this matter as long as nothing changes.

### Issue Number
> Related issue: #1916
