### PR TITLE
AUTH_PROVIDER log when incorrect and show error in login page

### DIFF
--- a/public/locales/en/authentication/login.json
+++ b/public/locales/en/authentication/login.json
@@ -14,7 +14,8 @@
     "buttons": {
       "submit": "Sign in"
     },
-    "afterLoginRedirection": "After login, you'll be redirected to {{url}}"
+    "afterLoginRedirection": "After login, you'll be redirected to {{url}}",
+    "providersEmpty": "The provider(s) are unset, please check your logs for more information."
   },
   "alert": "Your credentials are incorrect or this account doesn't exist. Please try again."
 }

--- a/public/locales/en/authentication/login.json
+++ b/public/locales/en/authentication/login.json
@@ -15,7 +15,10 @@
       "submit": "Sign in"
     },
     "afterLoginRedirection": "After login, you'll be redirected to {{url}}",
-    "providersEmpty": "The provider(s) are unset, please check your logs for more information."
+    "providersEmpty": {
+      "title": "Auth Provider Error",
+      "message": "The provider(s) are unset, please check your logs for more information."
+    }
   },
   "alert": "Your credentials are incorrect or this account doesn't exist. Please try again."
 }

--- a/src/env.js
+++ b/src/env.js
@@ -17,6 +17,7 @@ const portSchema = z
   .optional();
 const envSchema = z.enum(['development', 'test', 'production']);
 
+const validAuthProviders = ['credentials', 'ldap', 'oidc'];
 const authProviders = process.env.AUTH_PROVIDER?.replaceAll(' ', '').split(',') || ['credentials'];
 
 const env = createEnv({
@@ -43,8 +44,21 @@ const env = createEnv({
     // Authentication
     AUTH_PROVIDER: z
       .string()
+      .min(1)
       .default('credentials')
-      .transform((providers) => providers.replaceAll(' ', '').split(',')),
+      .transform((providers) =>
+        providers
+          .replaceAll(' ', '')
+          .split(',')
+          .filter((provider) => {
+            if (validAuthProviders.includes(provider)) return provider;
+            else if (!provider)
+              console.log(
+                `One or more of the entries for AUTH_PROVIDER could not be parsed and/or returned null.`
+              );
+            else console.log(`The value entered for AUTH_PROVIDER "${provider}" is incorrect.`);
+          })
+      ),
     // LDAP
     ...(authProviders.includes('ldap')
       ? {

--- a/src/env.js
+++ b/src/env.js
@@ -49,6 +49,7 @@ const env = createEnv({
       .transform((providers) =>
         providers
           .replaceAll(' ', '')
+          .toLowerCase()
           .split(',')
           .filter((provider) => {
             if (validAuthProviders.includes(provider)) return provider;

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -125,9 +125,13 @@ export default function LoginPage({
               </Title>
 
               {(providers.length < 1 && (
-                <Text align="center" mt={5}>
-                  {t('form.providersEmpty')}
-                </Text>
+                <Alert
+                  icon={<IconAlertTriangle size="1rem" />}
+                  title={t('form.providersEmpty.title')}
+                  mt={5}
+                >
+                  {t('form.providersEmpty.message')}
+                </Alert>
               )) || (
                 <Text color="dimmed" size="sm" align="center" mt={5} mb="md">
                   {t('text')}

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -124,9 +124,15 @@ export default function LoginPage({
                 {t('title')}
               </Title>
 
-              <Text color="dimmed" size="sm" align="center" mt={5} mb="md">
-                {t('text')}
-              </Text>
+              {(providers.length < 1 && (
+                <Text align="center" mt={5}>
+                  {t('form.providersEmpty')}
+                </Text>
+              )) || (
+                <Text color="dimmed" size="sm" align="center" mt={5} mb="md">
+                  {t('text')}
+                </Text>
+              )}
 
               {isError && (
                 <Alert icon={<IconAlertTriangle size="1rem" />} color="red">


### PR DESCRIPTION
### Category
> One of: Bugfix / Feature

### Overview
> Incorrectly setting up AUTH_PROVIDER did not make any feedback.
> Added 2 log message:
> - Provider empty: `One or more of the entries for AUTH_PROVIDER could not be parsed and/or returned null.`
> - Unrecognized provider `The value entered for AUTH_PROVIDER "${provider}" is incorrect.`
> Added message on the login page if absolutely no providers entered work.

### Screenshot
> ![image](https://github.com/ajnart/homarr/assets/26098587/a376bd01-e6bf-449b-93e8-f050da3fdef8)

