### PR TITLE
Add column ordering in torrent widget

### DIFF
--- a/src/widgets/torrent/TorrentTile.tsx
+++ b/src/widgets/torrent/TorrentTile.tsx
@@ -16,7 +16,7 @@ import { IconFileDownload } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { type MRT_ColumnDef, MRT_TableContainer, useMantineReactTable } from 'mantine-react-table';
+import { MRT_TableContainer, useMantineReactTable, type MRT_ColumnDef } from 'mantine-react-table';
 import { useTranslation } from 'next-i18next';
 import { useMemo } from 'react';
 import { MIN_WIDTH_MOBILE } from '~/constants/constants';
@@ -218,6 +218,7 @@ function TorrentTile({ widget }: TorrentTileProps) {
     enableRowVirtualization: true,
     rowVirtualizerProps: { overscan: 20 },
     mantineTableContainerProps: { sx: { scrollbarWidth: 'none' } },
+    enableColumnOrdering: true,
     enableSorting: true,
     initialState: {
       showColumnFilters: false,


### PR DESCRIPTION
### Category
> Feature

### Overview
> Add column ordering in torrent widget

### Issue Number
> Related issue: #1831

### Screenshot
> 
<img width="1177" alt="Screenshot 2024-03-10 at 20 42 38" src="https://github.com/ajnart/homarr/assets/950010/0b2eb02f-878f-4d13-810f-8ef5f0dc08e6">

