### PR TITLE
:bug: Added playsInline to VideoBackground

### DIFF
--- a/src/components/layout/Templates/BoardLayout.tsx
+++ b/src/components/layout/Templates/BoardLayout.tsx
@@ -285,6 +285,7 @@ const BackgroundVideo = ({videoSource, videoFormat}: BackgroundVideoProps) => {
         autoPlay
         muted
         loop
+        playsInline
         style={{
           position: 'fixed',
           width: '100vw',


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Added `playsInline` attribute to `VideoBackground` component to ensure video playback in the background on iOS/Mobil

### Issue Number _(if applicable)_
> N/A

### New Vars _(if applicable)_
> N/A

### Screenshot _(if applicable)_
> N/A
