### PR TITLE
Fix ping indicators floating above header in board customization page

### DIFF
--- a/src/components/Board/Customize/Layout/LayoutPreview.tsx
+++ b/src/components/Board/Customize/Layout/LayoutPreview.tsx
@@ -114,6 +114,7 @@ const PlaceholderElement = ({ height, width, showPing, index }: PlaceholderEleme
         size={5}
         offset={10}
         color={index % 4 === 0 ? 'red' : 'green'}
+        zIndex={0}
       >
         <BaseElement width={width} height={height} />
       </Indicator>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,5 +1,4 @@
 import {
-  Anchor,
   Box,
   Center,
   Flex,
@@ -8,11 +7,11 @@ import {
   Text,
   Title,
   UnstyledButton,
-  useMantineTheme,
+  useMantineTheme
 } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { IconAlertTriangle } from '@tabler/icons-react';
-import { Trans, useTranslation } from 'next-i18next';
+import { useTranslation } from 'next-i18next';
 
 import { Logo } from '../Common/Logo';
 import { AvatarMenu } from './AvatarMenu';

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -44,7 +44,7 @@ export const MainHeader = ({
     : headerBaseHeight;
 
   return (
-    <Header height={headerHeight} pb="sm" pt={0}>
+    <Header height={headerHeight} pb="sm" pt={0} style={{ zIndex: 200 }}>
       <Group spacing="xl" mt="xs" px="md" position="apart" noWrap>
         <Group noWrap style={{ flex: 1 }}>
           {leftIcon}

--- a/src/widgets/media-requests/MediaRequestStatsTile.tsx
+++ b/src/widgets/media-requests/MediaRequestStatsTile.tsx
@@ -156,6 +156,7 @@ function MediaRequestStatsTile({ widget }: MediaRequestStatsWidgetProps) {
                       left={8}
                       size={15}
                       ml={-5}
+                      zIndex={1}
                       color={user.app === 'overseerr' ? '#ECB000' : '#6677CC'}
                       processing={mediaFetching || usersFetching}
                       children


### PR DESCRIPTION
Just started using Homarr yesterday and noticed this bug #1997

### Category
Bugfix

### Overview
- The z-index of ping indicators is 100 which is the same as the header. Override the z-index to 0.
- Increased header's z-index to 200 to prevent other elements like grid resize handle from floating over it. App tile menus will still float over the header as expected.

**Before fix:**
![image](https://github.com/ajnart/homarr/assets/4703366/dbe10bee-7eec-4cb5-aa23-26ba4108da56)

**After fix:**
![image](https://github.com/ajnart/homarr/assets/4703366/9c3ba87e-127b-409b-bdd4-d8ff3bdbd513)

### Issue Number
Fixes  #1997
Same as #1401
