### PR TITLE
OIDC Timeout

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -12,6 +12,12 @@ const zodParsedBoolean = () =>
     .default('false')
     .transform((value) => trueStrings.includes(value));
 
+const numberSchema = z
+  .string()
+  .regex(/\d*/)
+  .transform((value) => (value === undefined ? undefined : Number(value)))
+  .optional()
+
 const portSchema = z
   .string()
   .regex(/\d*/)
@@ -90,6 +96,7 @@ const env = createEnv({
           AUTH_OIDC_OWNER_GROUP: z.string().default('admin'),
           AUTH_OIDC_AUTO_LOGIN: zodParsedBoolean(),
           AUTH_OIDC_SCOPE_OVERWRITE: z.string().default('openid email profile groups'),
+          AUTH_OIDC_TIMEOUT: numberSchema.default(3500)
         }
       : {}),
   },
@@ -149,6 +156,7 @@ const env = createEnv({
     AUTH_OIDC_OWNER_GROUP: process.env.AUTH_OIDC_OWNER_GROUP,
     AUTH_OIDC_AUTO_LOGIN: process.env.AUTH_OIDC_AUTO_LOGIN,
     AUTH_OIDC_SCOPE_OVERWRITE: process.env.AUTH_OIDC_SCOPE_OVERWRITE,
+    AUTH_OIDC_TIMEOUT: process.env.AUTH_OIDC_TIMEOUT,
     DEMO_MODE: process.env.DEMO_MODE,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,

--- a/src/utils/auth/oidc.ts
+++ b/src/utils/auth/oidc.ts
@@ -50,6 +50,9 @@ const createProvider = (headers: OidcRedirectCallbackHeaders): OAuthConfig<Profi
     },
   },
   idToken: true,
+  httpOptions: {
+    timeout: env.AUTH_OIDC_TIMEOUT,
+  },
   async profile(profile) {
     const user = await adapter.getUserByEmail!(profile.email);
 


### PR DESCRIPTION
Hi Tomas (@ajnart), I have exactly the same issue reported on #1995 , this is a simple fix that can resolve a lot of headaches to the users that want to use OIDC (Because everything can be configured correctly, however if the latency between the service it's not enough will be fail)

### Category
Bugfix

### Overview
if the OIDC provider don't respond in less than 3500ms (Default NextAuth Implementation) the connection fails between Hommar backend and the OIDC provider.

This PR add a new config parameter to increase the timeout using `AUTH_OIDC_TIMEOUT`

### Issue Number 1995
https://github.com/ajnart/homarr/issues/1995

### New Vars _(if applicable)_
- Added AUTH_OIDC_TIMEOUT env variable keeping the same structure as the rest of AUTH_OIDC_XXXX Configs
- I added 4 files related to DevEnv (https://devenv.sh/) to support nix.

### Screenshot _(if applicable)_
No Applicable
