### PR TITLE
Home Assistant entity generic toggle

### DIFF
--- a/public/locales/en/modules/smart-home/entity-state.json
+++ b/public/locales/en/modules/smart-home/entity-state.json
@@ -22,8 +22,13 @@
             },
             "displayFriendlyName": {
                 "label": "Display friendly name",
-                "info": "Display friendly name from Home Assistant instead instead of display name"
+                "info": "Display friendly name from Home Assistant instead instead of display name."
+            },
+            "genericToggle": {
+                "label": "Entity toggle",
+                "info": "Perform a generic Home Assistant toggle action on entity when clicked."
             }
         }
     }
 }
+

--- a/src/tools/server/sdk/homeassistant/HomeAssistant.ts
+++ b/src/tools/server/sdk/homeassistant/HomeAssistant.ts
@@ -56,4 +56,28 @@ export class HomeAssistant {
       return false;
     }
   }
+
+  /**
+   * Triggers a toggle action for a specific entity.
+   * 
+   * @param entityId - The ID of the entity to toggle.
+   * @returns A boolean indicating whether the toggle action was successful.
+   */
+  async triggerToggle(entityId: string) {
+    try {
+      const response = await fetch(appendPath(this.basePath, `/services/homeassistant/toggle`), {
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+        },
+        body: JSON.stringify({
+          'entity_id': entityId,
+        }),
+        method: 'POST'
+      });
+      return response.ok;
+    } catch (err) {
+      Consola.error(`Failed to fetch from '${this.basePath}': ${err}`);
+      return false;
+    }
+  }
 }

--- a/src/widgets/smart-home/entity-state/entity-state.widget.tsx
+++ b/src/widgets/smart-home/entity-state/entity-state.widget.tsx
@@ -21,6 +21,11 @@ const definition = defineWidget({
       defaultValue: false,
       info: true,
     },
+    genericToggle: {
+      type: 'switch',
+      defaultValue: false,
+      info: true,
+    },
     automationId: {
       type: 'text',
       info: true,
@@ -82,15 +87,26 @@ function EntityStateTile({ widget }: SmartHomeEntityStateWidgetProps) {
     },
   });
 
-  const handleClick = async () => {
-    if (!widget.properties.automationId) {
-      return;
-    }
+  const { mutateAsync: mutateTriggerToggleSync } = api.smartHomeEntityState.triggerToggle.useMutation({
+    onSuccess: () => {
+      void utils.smartHomeEntityState.invalidate();
+    },
+  });
 
-    await mutateTriggerAutomationAsync({
-      configName: configName as string,
-      widgetId: widget.id,
-    });
+  const handleClick = async () => {
+    if (widget.properties.genericToggle) {
+      await mutateTriggerToggleSync({
+        configName: configName as string,
+        widgetId: widget.id,
+      });
+    } 
+    
+    if (widget.properties.automationId) {
+      await mutateTriggerAutomationAsync({
+        configName: configName as string,
+        widgetId: widget.id,
+      });
+    }
   };
 
   let dataComponent = null;


### PR DESCRIPTION
Added support for generic toggle on Home Assistant entities that support it. For entities that does not support toggle the feature will silently fail. This way matches how Home Assistant handles it.

### Category
> Feature

### Overview
> Currently when enabling both toggle and automation both will run on click. I am not sure what the best way of handling this is so that it is intuitive for the user. Personally i do not mind if it runs both when you have configured both but I'd love input on this.

### Issue Number
> #1848

### New Vars
> Entity toggle switch on the home assistant entity card.

