### PR TITLE
fix: Avatar host

### DIFF
--- a/src/components/layout/header/AvatarMenu.tsx
+++ b/src/components/layout/header/AvatarMenu.tsx
@@ -88,10 +88,10 @@ type CurrentUserAvatarProps = {
   user: User | null;
 };
 
-const getGravatar = (email?: string | undefined | null) => {
+const getAvatarLink = (email?: string | undefined | null) => {
   if (!email) return null;
   const emailHash = createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
-  return `https://gravatar.com/avatar/${emailHash}?d=null`;
+  return `https://seccdn.libravatar.org/avatar/${emailHash}?d=404`;
 };
 
 const CurrentUserAvatar = forwardRef<HTMLDivElement, CurrentUserAvatarProps>(
@@ -100,18 +100,16 @@ const CurrentUserAvatar = forwardRef<HTMLDivElement, CurrentUserAvatarProps>(
     const { fn } = useMantineTheme();
     const border = fn.variant({ variant: 'default' }).border;
 
-    if (!user)
-      return <Avatar ref={ref} styles={{ root: { border: `1px solid ${border}` } }} {...others} />;
-
     return (
       <Avatar
         ref={ref}
-        color={primaryColor}
-        src={getGravatar(user.email)}
-        styles={{ root: { border: `1px solid ${border}` } }}
+        color={user == null ? undefined : primaryColor}
+        src={getAvatarLink(user?.email)}
+        alt={user?.name?.slice(0, 2).toUpperCase() ?? "anon"}
+        styles={{ root: { border: `1px solid ${border}` }, image: {} }}
         {...others}
       >
-        {user.name?.slice(0, 2).toUpperCase()}
+        {user?.name?.slice(0, 2).toUpperCase()}
       </Avatar>
     );
   }


### PR DESCRIPTION
### Category
> bugfix

### Overview
> 1. Default address with null used to link to "http://i0.wp.com/null" which made the connection insecure. Changed default to 404.
> 2. Use libravatar instead of gravatar. Open-source and proxies gravatar when they don't have it themselves.
> (3. refactored the avatar element a little)

### Issue Number
> Closes #1944