### PR TITLE
AUTH_OIDC_TIMEOUT make default a string

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -105,7 +105,7 @@ const env = createEnv({
           AUTH_OIDC_OWNER_GROUP: z.string().default('admin'),
           AUTH_OIDC_AUTO_LOGIN: zodParsedBoolean(),
           AUTH_OIDC_SCOPE_OVERWRITE: z.string().default('openid email profile groups'),
-          AUTH_OIDC_TIMEOUT: numberSchema.default(3500),
+          AUTH_OIDC_TIMEOUT: numberSchema.default('3500'),
         }
       : {}),
   },


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> AUTH_OIDC_TIMEOUT is set default to a number but needs a string and thus causes an error.
> Supposed to be fixed already in #2023 but got reverted somehow in #2033.
