### PR TITLE
Add `key` for custom favicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier:check": "prettier --check \"**/*.{ts,tsx}\"",
     "prettier:write": "prettier --write \"**/*.{ts,tsx}\"",
     "test": "SKIP_ENV_VALIDATION=1 vitest",
+    "test:docker": "yarn run turbo build && yarn test:run && docker build . -t homarr:local-dev && docker run -p 7575:7575 --name homarr-dev homarr:local-dev",
     "test:ui": "SKIP_ENV_VALIDATION=1 vitest --ui",
     "test:run": "SKIP_ENV_VALIDATION=1 vitest run",
     "test:coverage": "SKIP_ENV_VALIDATION=1 vitest run --coverage",

--- a/src/components/layout/Meta/BoardHeadOverride.tsx
+++ b/src/components/layout/Meta/BoardHeadOverride.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import React from 'react';
 import { useConfigContext } from '~/config/provider';
 import { firstUpperCase } from '~/tools/shared/strings';
 
@@ -15,7 +14,7 @@ export const BoardHeadOverride = () => {
   return (
     <Head>
       <title>{title}</title>
-      <meta name="apple-mobile-web-app-title" content={title} />
+      <meta key="favicon" name="apple-mobile-web-app-title" content={title} />
 
       {faviconUrl && faviconUrl.length > 0 && (
         <>

--- a/src/components/layout/Meta/BoardHeadOverride.tsx
+++ b/src/components/layout/Meta/BoardHeadOverride.tsx
@@ -14,13 +14,13 @@ export const BoardHeadOverride = () => {
   return (
     <Head>
       <title>{title}</title>
-      <meta key="favicon" name="apple-mobile-web-app-title" content={title} />
+      <meta name="apple-mobile-web-app-title" content={title} />
 
       {faviconUrl && faviconUrl.length > 0 && (
         <>
-          <link rel="shortcut icon" href={faviconUrl} />
+          <link key="favicon" rel="shortcut icon" href={faviconUrl} />
 
-          <link rel="apple-touch-icon" href={faviconUrl} />
+          <link key="favicon-apple" rel="apple-touch-icon" href={faviconUrl} />
         </>
       )}
     </Head>

--- a/src/components/layout/Meta/CommonHead.tsx
+++ b/src/components/layout/Meta/CommonHead.tsx
@@ -7,7 +7,7 @@ export const CommonHead = () => {
   return (
     <Head>
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-      <link rel="shortcut icon" href="/imgs/favicon/favicon.svg" />
+      <link key="favicon" rel="shortcut icon" href="/imgs/favicon/favicon.svg" />
 
       <link crossOrigin="use-credentials" rel="manifest" href="/site.webmanifest" />
 

--- a/src/components/layout/Meta/CommonHead.tsx
+++ b/src/components/layout/Meta/CommonHead.tsx
@@ -12,7 +12,7 @@ export const CommonHead = () => {
       <link crossOrigin="use-credentials" rel="manifest" href="/site.webmanifest" />
 
       {/* configure apple splash screen & touch icon */}
-      <link rel="apple-touch-icon" href="/imgs/favicon/favicon.svg" />
+      <link key="favicon-apple" rel="apple-touch-icon" href="/imgs/favicon/favicon.svg" />
       <meta name="apple-mobile-web-app-title" content="Homarr" />
 
       <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
Reference https://nextjs.org/docs/pages/api-reference/components/head#avoid-duplicated-tags

<img width="217" alt="image" src="https://github.com/ajnart/homarr/assets/49837342/b5fd078a-80c7-476a-85f4-966fee32d3a1">



Closes #1676 