### PR TITLE
Add dismissible alert for homarr v1.0

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
-import { ColorScheme as MantineColorScheme, MantineProvider, MantineTheme } from '@mantine/core';
+import { ColorScheme as MantineColorScheme, MantineProvider, MantineTheme, Alert } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
 import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -100,6 +101,11 @@ function App(
     setInitialPackageAttributes(props.pageProps.packageAttributes);
   }, []);
 
+  const [alertDismissed, setAlertDismissed] = useLocalStorage({
+    key: 'homarr-v1.0-alert-dismissed',
+    defaultValue: false,
+  });
+
   return (
     <>
       <CommonHead />
@@ -148,6 +154,16 @@ function App(
                 <ConfigProvider {...props.pageProps}>
                   <Notifications limit={4} position="bottom-left" />
                   <ModalsProvider modals={modals}>
+                    {!alertDismissed && (
+                      <Alert
+                        title="Homarr v1.0"
+                        color="blue"
+                        withCloseButton
+                        onClose={() => setAlertDismissed(true)}
+                      >
+                        We are building a new version of Homarr, stay tuned!
+                      </Alert>
+                    )}
                     <Component {...pageProps} />
                   </ModalsProvider>
                 </ConfigProvider>

--- a/src/pages/manage/index.tsx
+++ b/src/pages/manage/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, createStyles, Group, Image, SimpleGrid, Stack, Text, Title, UnstyledButton } from '@mantine/core';
+import { Box, Card, createStyles, Group, Image, SimpleGrid, Stack, Text, Title, UnstyledButton, Alert } from '@mantine/core';
 import { IconArrowRight } from '@tabler/icons-react';
 import { GetServerSideProps } from 'next';
 import { useSession } from 'next-auth/react';
@@ -10,6 +10,7 @@ import { useScreenLargerThan } from '~/hooks/useScreenLargerThan';
 import { getServerAuthSession } from '~/server/auth';
 import { getServerSideTranslations } from '~/tools/server/getServerSideTranslations';
 import { OnlyKeysWithStructure } from '~/types/helpers';
+import { useLocalStorage } from '@mantine/hooks';
 
 import { type quickActions } from '../../../public/locales/en/manage/index.json';
 import { checkForSessionOrAskForLogin } from '~/tools/server/loginBuilder';
@@ -19,6 +20,10 @@ const ManagementPage = () => {
   const { classes } = useStyles();
   const largerThanMd = useScreenLargerThan('md');
   const { data: sessionData } = useSession();
+  const [alertDismissed, setAlertDismissed] = useLocalStorage({
+    key: 'homarr-v1.0-alert-dismissed',
+    defaultValue: false,
+  });
 
   const metaTitle = `${t('metaTitle')} • Homarr`;
   return (
@@ -26,6 +31,16 @@ const ManagementPage = () => {
       <Head>
         <title>{metaTitle}</title>
       </Head>
+      {!alertDismissed && (
+        <Alert
+          title="Homarr v1.0"
+          color="blue"
+          withCloseButton
+          onClose={() => setAlertDismissed(true)}
+        >
+          We are building a new version of Homarr, stay tuned!
+        </Alert>
+      )}
       <Box className={classes.box} w="100%" mih={150} p="xl" mb={50}>
         <Group position="apart" noWrap>
           <Stack spacing={15}>


### PR DESCRIPTION
Add a dismissible Mantine Alert at the top of the Management pages to inform users about homarr v1.0.

* **src/pages/_app.tsx**
  - Import `Alert` and `useLocalStorage` from `@mantine/core` and `@mantine/hooks`.
  - Add a dismissible `Alert` component at the top of the `App` component.
  - Use `useLocalStorage` to store the dismissal state of the alert.

* **src/pages/manage/index.tsx**
  - Import `Alert` and `useLocalStorage` from `@mantine/core` and `@mantine/hooks`.
  - Add a dismissible `Alert` component at the top of the `ManagementPage` component.
  - Use `useLocalStorage` to store the dismissal state of the alert.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ajnart/homarr?shareId=9e0e6bd0-2b9f-412e-82fd-8f37da30b333).