### PR TITLE
fix: removing a category hides items from the wrapper below

### DIFF
--- a/src/components/Dashboard/Wrappers/Category/useCategoryActions.tsx
+++ b/src/components/Dashboard/Wrappers/Category/useCategoryActions.tsx
@@ -185,14 +185,20 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
     updateConfig(
       configName,
       (previous) => {
-        const currentItem = previous.categories.find((x) => x.id === category.id);
+        const currentItem = previous.categories.find(
+          (previousCategory) => previousCategory.id === category.id
+        );
         if (!currentItem) return previous;
 
-        const currentWrapper = previous.wrappers.find((x) => x.position === currentItem?.position);
+        const currentWrapper = previous.wrappers.find(
+          (previousWrapper) => previousWrapper.position === currentItem?.position
+        );
         if (!currentWrapper) return previous;
 
         // Find the main wrapper
-        const mainWrapper = previous.wrappers.find((x) => x.position === 0);
+        const mainWrapper = previous.wrappers.find(
+          (previousWrapper) => previousWrapper.position === 0
+        );
         const mainWrapperId = mainWrapper?.id ?? 'default';
 
         const isAppAffectedFilter = (app: AppType): boolean => {
@@ -271,8 +277,12 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
                 })
               ),
           ],
-          categories: previous.categories.filter((x) => x.id !== category.id),
-          wrappers: previous.wrappers.filter((x) => x.position !== currentItem.position),
+          categories: previous.categories.filter(
+            (previousCategory) => previousCategory.id !== category.id
+          ),
+          wrappers: previous.wrappers.filter(
+            (previousWrapper) => previousWrapper.position !== currentItem.position
+          ),
         };
       },
       true

--- a/src/components/Dashboard/Wrappers/Category/useCategoryActions.tsx
+++ b/src/components/Dashboard/Wrappers/Category/useCategoryActions.tsx
@@ -187,6 +187,10 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
       (previous) => {
         const currentItem = previous.categories.find((x) => x.id === category.id);
         if (!currentItem) return previous;
+
+        const currentWrapper = previous.wrappers.find((x) => x.position === currentItem?.position);
+        if (!currentWrapper) return previous;
+
         // Find the main wrapper
         const mainWrapper = previous.wrappers.find((x) => x.position === 0);
         const mainWrapperId = mainWrapper?.id ?? 'default';
@@ -196,7 +200,7 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
             return false;
           }
 
-          if (app.area.type !== 'category') {
+          if (app.area.type === 'sidebar') {
             return false;
           }
 
@@ -204,7 +208,10 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
             return false;
           }
 
-          return app.area.properties.id === currentItem.id;
+          return (
+            app.area.properties.id === currentItem.id ||
+            app.area.properties.id === currentWrapper.id
+          );
         };
 
         const isWidgetAffectedFilter = (widget: IWidget<string, any>): boolean => {
@@ -212,7 +219,7 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
             return false;
           }
 
-          if (widget.area.type !== 'category') {
+          if (widget.area.type === 'sidebar') {
             return false;
           }
 
@@ -220,7 +227,10 @@ export const useCategoryActions = (configName: string | undefined, category: Cat
             return false;
           }
 
-          return widget.area.properties.id === currentItem.id;
+          return (
+            widget.area.properties.id === currentItem.id ||
+            widget.area.properties.id === currentWrapper.id
+          );
         };
 
         return {


### PR DESCRIPTION
### Category
> Bugfix 

### Overview
> Also marked apps and widgets as affected that are in the wrapper below the category (is also removed)

### Issue Number
> Related issue: https://discord.com/channels/972958686051962910/1066060995094646936

### Screenrecordings

#### Previeus
![Bildschirmaufnahme 2024-08-08 204852](https://github.com/user-attachments/assets/164f65b4-9f0a-4d87-8ad3-0eea705c4e30)

#### After
![Bildschirmaufnahme 2024-08-08 204433](https://github.com/user-attachments/assets/879e38b6-4c8e-401e-b59d-a4e19c03edde)
