### PR TITLE
fix: notebook widget overflow on mobile

### DIFF
--- a/src/widgets/notebook/NotebookWidgetTile.tsx
+++ b/src/widgets/notebook/NotebookWidgetTile.tsx
@@ -27,7 +27,7 @@ const definition = defineWidget({
     },
   },
   gridstack: {
-    minWidth: 2,
+    minWidth: 1,
     minHeight: 1,
     maxWidth: 12,
     maxHeight: 12,


### PR DESCRIPTION
Greetings

### Category
> Bugfix

### Overview
> Testing and handling a board with mobile size with 1 column, found that by default the notebook widget requires 2 width columns, causing an overflow on the view and might not be ideal. I get why was implemented in the first place and make sure that as soon that the widget has the appropiate size as soon is created, but maybe is required a better implementation that allow min width columns per screen device? but that's a challenge. For the moment, this will fix the overflow.

### Screenshot 

Before:
![image](https://github.com/user-attachments/assets/77756183-019f-4f64-9d0a-6455d8fb1373)

After:
![image](https://github.com/user-attachments/assets/a9d29d7c-cd66-460e-86f0-3bd8b965db77)

I hope you find it useful.
