### PR TITLE
fix: Make timer button show only to admins

### DIFF
--- a/src/widgets/dnshole/DnsHoleControls.tsx
+++ b/src/widgets/dnshole/DnsHoleControls.tsx
@@ -279,18 +279,20 @@ function DnsHoleControlsWidgetTile({ widget }: DnsHoleControlsWidgetProps) {
                         {t(dnsHole.status)}
                       </Badge>
                     </UnstyledButton>
-                    <ActionIcon
-                      size={20}
-                      radius="xl"
-                      top="2.67px"
-                      variant="default"
-                      onClick={() => {
-                        setAppId(app.id);
-                        open();
-                      }}
-                    >
-                      <IconClockPause size={20} color="red" />
-                    </ActionIcon>
+                    {enableControls && (
+                      <ActionIcon
+                        size={20}
+                        radius="xl"
+                        top="2.67px"
+                        variant="default"
+                        onClick={() => {
+                          setAppId(app.id);
+                          open();
+                        }}
+                      >
+                        <IconClockPause size={20} color="red" />
+                      </ActionIcon>
+                    )}
                   </Flex>
                 </Stack>
               </Group>


### PR DESCRIPTION
### Category
> Bugfix: Timer control for individual elements was still apparent to non admin users

### Overview
> Make button appear only if admin

### Issue Number 
> Discord Report https://discord.com/channels/972958686051962910/1289780222434086984