### PR TITLE
Use Public Suffix for homarr_domain

### DIFF
--- a/src/hooks/useExternalUrl.ts
+++ b/src/hooks/useExternalUrl.ts
@@ -9,7 +9,7 @@ export const useGetExternalUrl = () => {
 
   const parsedUrl = useMemo(() => {
     try {
-      return tldts.parse(window.location.toString());
+      return tldts.parse(window.location.toString(), { allowPrivateDomains: true });
     } catch {
       return null;
     }
@@ -21,7 +21,7 @@ export const useGetExternalUrl = () => {
         return appType.behaviour.externalUrl
           .replace('[homarr_base]', `${window.location.protocol}//${window.location.hostname}`)
           .replace('[homarr_hostname]', parsedUrl?.hostname ?? '')
-          .replace('[homarr_domain]', parsedUrl?.domain ?? '')
+          .replace('[homarr_domain]', parsedUrl?.publicSuffix ?? '')
           .replace('[homarr_protocol]', window.location.protocol.replace(':', ''));
       }
       return appType.url;


### PR DESCRIPTION
### Category
Feature

### Overview

Changes the `homarr_domain` detection to take the complete domain rather than the top domain only.

When the domain of homarr is `homarr.myMachine.domain.tld`, `myMachine.domain.tld` is detected as `publicSuffix`

This makes use of `allowPrivateDomains` to detect the suffix as documented on https://www.npmjs.com/package/tldts

```
tldts.parse('https://spark-public.s3.amazonaws.com/dataanalysis/loansData.csv');
// { domain: 'amazonaws.com',
//   domainWithoutSuffix: 'amazonaws',
//   hostname: 'spark-public.s3.amazonaws.com',
//   isIcann: true,
//   isIp: false,
//   isPrivate: false,
//   publicSuffix: 'com',
//   subdomain: 'spark-public.s3' }

tldts.parse(
  'https://spark-public.s3.amazonaws.com/dataanalysis/loansData.csv',
  { allowPrivateDomains: true },
);
// { domain: 'spark-public.s3.amazonaws.com',
//   domainWithoutSuffix: 'spark-public',
//   hostname: 'spark-public.s3.amazonaws.com',
//   isIcann: false,
//   isIp: false,
//   isPrivate: true,
//   publicSuffix: 's3.amazonaws.com',
//   subdomain: '' }
```

### Issue Number
Related issue: #2146
