### PR TITLE
fix: credentials login behind proxy no longer works

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -7,6 +7,7 @@ import { decode, encode } from 'next-auth/jwt';
 import { env } from '~/env';
 import { secondsFromTimeString } from '~/tools/client/parseDuration';
 import { adapter, getProviders, onCreateUser } from '~/utils/auth';
+import { createCookiesWithDefaultOptions } from '~/utils/auth/cookies';
 import { createRedirectUri } from '~/utils/auth/oidc';
 import EmptyNextAuthProvider from '~/utils/empty-provider';
 import { fromDate, generateSessionToken } from '~/utils/session';
@@ -106,17 +107,7 @@ export const constructAuthOptions = async (
   },
   adapter: adapter as Adapter,
   providers: [...(await getProviders(req.headers)), EmptyNextAuthProvider()],
-  cookies: {
-    sessionToken: {
-      name: 'next-auth.session-token',
-      options: {
-        httpOnly: true,
-        sameSite: 'lax',
-        path: '/',
-        secure: true,
-      },
-    },
-  },
+  cookies: createCookiesWithDefaultOptions(req.url?.startsWith('https:') ?? false),
   jwt: {
     async encode(params) {
       if (!isCredentialsRequest(req)) {

--- a/src/utils/auth/cookies.ts
+++ b/src/utils/auth/cookies.ts
@@ -1,0 +1,66 @@
+export const createCookiesWithDefaultOptions = (useSecureCookies: boolean) => {
+  const cookiePrefix = useSecureCookies ? '__Secure-' : '';
+
+  return {
+    // default cookie options
+    sessionToken: {
+      // We don't use __Secure prefix as the cookie is used in the code
+      name: `next-auth.session-token`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+      },
+    },
+    callbackUrl: {
+      name: `${cookiePrefix}next-auth.callback-url`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+      },
+    },
+    csrfToken: {
+      // Default to __Host- for CSRF token for additional protection if using useSecureCookies
+      // NB: The `__Host-` prefix is stricter than the `__Secure-` prefix.
+      name: `${useSecureCookies ? '__Host-' : ''}next-auth.csrf-token`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+      },
+    },
+    pkceCodeVerifier: {
+      name: `${cookiePrefix}next-auth.pkce.code_verifier`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+        maxAge: 60 * 15, // 15 minutes in seconds
+      },
+    },
+    state: {
+      name: `${cookiePrefix}next-auth.state`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+        maxAge: 60 * 15, // 15 minutes in seconds
+      },
+    },
+    nonce: {
+      name: `${cookiePrefix}next-auth.nonce`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+      },
+    },
+  } as const;
+};


### PR DESCRIPTION
This pull request should resolve the issue seen by some people using http protocol and a reverse proxy.

**How did I test?**
- I setup a traefik proxy with homarr (copied from #2171) and used it to test my locally created image
- I'll ask people from the issue if they can confirm that the test image, I'll build, fixes there issue.

**What was the cause?**
- Adding the setting for Sessiontoken cookie and AUTH_TRUST_HOST env variable resulted in it using __Secure prefix always, which caused those no longer to work in http environments. See more about cookie prefixes [here](https://datatracker.ietf.org/doc/html/draft-west-cookie-prefixes-05#section-3)

Closes #2171 
Closes https://discord.com/channels/972958686051962910/1300015887230828605