### PR TITLE
fix: remove several occurrences of translation file prefix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
 		"layout.manage.navigation.**",
 	],
 	"editor.codeActionsOnSave": {
-		"source.organizeImports": true
+		"source.organizeImports": "explicit"
 	},
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"explorer.fileNesting.patterns": {

--- a/src/widgets/dnshole/TimerModal.tsx
+++ b/src/widgets/dnshole/TimerModal.tsx
@@ -41,12 +41,12 @@ export function TimerModal({ toggleDns, getDnsStatus, opened, close, appId }: Ti
         setHours(0);
         setMinutes(0);
       }}
-      title={t('modules/dns-hole-controls:durationModal.title')}
+      title={t('durationModal.title')}
     >
       <Flex direction="column" align="center" justify="center">
         <Stack align="flex-end">
           <Group spacing={5}>
-            <Text>{t('modules/dns-hole-controls:durationModal.hours')}</Text>
+            <Text>{t('durationModal.hours')}</Text>
             <ActionIcon
               size={35}
               variant="default"
@@ -73,7 +73,7 @@ export function TimerModal({ toggleDns, getDnsStatus, opened, close, appId }: Ti
             </ActionIcon>
           </Group>
           <Group spacing={5}>
-            <Text>{t('modules/dns-hole-controls:durationModal.minutes')}</Text>
+            <Text>{t('durationModal.minutes')}</Text>
             <ActionIcon
               size={35}
               variant="default"
@@ -101,7 +101,7 @@ export function TimerModal({ toggleDns, getDnsStatus, opened, close, appId }: Ti
           </Group>
         </Stack>
         <Text ta="center" c="dimmed" my={5}>
-          {t('modules/dns-hole-controls:durationModal.unlimited')}
+          {t('durationModal.unlimited')}
         </Text>
         <Button
           variant="light"
@@ -116,7 +116,7 @@ export function TimerModal({ toggleDns, getDnsStatus, opened, close, appId }: Ti
             close();
           }}
         >
-          {t('modules/dns-hole-controls:durationModal.set')}
+          {t('durationModal.set')}
         </Button>
       </Flex>
     </Modal>


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
>Bugfix

### Overview
> Prefix that points to translation file was defined not only in the method defintion but also in the method call

### Issue Number _(if applicable)_
> Related issue: #2187 

### New Vars _(if applicable)_
> No new vars.

### Screenshot _(if applicable)_
> No significant UI changes.
