### PR TITLE
fix: unable to delete boards with capitalised name 'Default'

### DIFF
--- a/src/server/api/routers/config.ts
+++ b/src/server/api/routers/config.ts
@@ -23,7 +23,7 @@ export const configRouter = createTRPCRouter({
     )
     .output(z.object({ message: z.string() }))
     .mutation(async ({ input }) => {
-      if (input.name.toLowerCase() === 'default') {
+      if (input.name === 'default') {
         Consola.error("Rejected config deletion because default configuration can't be deleted");
         throw new TRPCError({
           code: 'FORBIDDEN',


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
> Bugfix

### Overview
> You can create multiple boards called default as long as the capitalisation is different for each one ('eg 'Default', 'DeFaUlT'), however, when we try to prevent deleting the 'default' board the check is case insensitive and therefore we can't delete these fake default boards. As a side note, I think users should not be allowed to create multiple boards with the same name but different capitalisation in the first place but that seems to be a common theme in other parts of the app.
