### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     <strong>Demo ✨</strong>
   </a>
   •
-  <a href="https://homarr.dev/docs/getting-started/installation/">
+  <a href="https://homarr.dev/docs/category/installation-1/">
     <strong>Install 💻</strong>
   </a> •
   <a href="https://translate.homarr.dev/">


### PR DESCRIPTION
Corrected website link for INSTALL in readme.

### Category
> Documentation 

### Overview
> Link for installation in readme that works.


### Screenshot _(if applicable)_
Old link:
![image](https://github.com/user-attachments/assets/5c8f7f62-ea4b-46d9-9226-2bf0a1d90520)

New link on install redirects to working page.
![image](https://github.com/user-attachments/assets/47b0a7eb-cb7e-4090-aa9b-556e09322722)


