### PR TITLE
docs: update readme with correct link for getting started.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ https://user-images.githubusercontent.com/30572287/217098893-5880e7de-13d0-42c5-
 
 Since we are updating Homarr very frequently, we recommend reading our official installation guides:
 
-<a href="https://homarr.dev/docs/getting-started/installation/">
+<a href="https://homarr.dev/docs/category/installation-1/">
   <img src="docs/installation-button.png" width="200" />
 </a>
 


### PR DESCRIPTION
Corrected website link for INSTALL in readme.

### Category
> Documentation 

### Overview
> Link for installation in readme that works.


### Screenshot _(if applicable)_
Old link:
![image](https://github.com/user-attachments/assets/5c8f7f62-ea4b-46d9-9226-2bf0a1d90520)

New link on install redirects to working page.
![image](https://github.com/user-attachments/assets/47b0a7eb-cb7e-4090-aa9b-556e09322722)


